### PR TITLE
Use custom scheme for oauth redirect

### DIFF
--- a/source/Gnomeshade.Avalonia.Core/Authentication/Browser.cs
+++ b/source/Gnomeshade.Avalonia.Core/Authentication/Browser.cs
@@ -3,17 +3,10 @@
 // See LICENSE.txt file in the project root for full license information.
 
 using System;
-using System.IO;
-using System.Net;
-using System.Reflection;
-using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
 
 using IdentityModel.OidcClient.Browser;
-
-using static System.Net.HttpStatusCode;
-using static System.StringComparison;
 
 using static IdentityModel.OidcClient.Browser.BrowserResultType;
 
@@ -22,40 +15,35 @@ namespace Gnomeshade.Avalonia.Core.Authentication;
 /// <inheritdoc />
 public abstract class Browser : IBrowser
 {
-	private const string _formUrlEncoded = "application/x-www-form-urlencoded";
-
+	private readonly IGnomeshadeProtocolHandler _gnomeshadeProtocolHandler;
 	private readonly TimeSpan _timeout;
 
 	/// <summary>Initializes a new instance of the <see cref="Browser"/> class.</summary>
+	/// <param name="gnomeshadeProtocolHandler">Handler for gnomeshade protocol requests.</param>
 	/// <param name="timeout">The time to wait until user completes signin.</param>
-	protected Browser(TimeSpan timeout)
+	protected Browser(IGnomeshadeProtocolHandler gnomeshadeProtocolHandler, TimeSpan timeout)
 	{
+		_gnomeshadeProtocolHandler = gnomeshadeProtocolHandler;
 		_timeout = timeout;
 	}
 
 	/// <inheritdoc />
 	public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken)
 	{
-		using var httpListener = new HttpListener();
-		httpListener.Prefixes.Add(options.EndUrl);
-		httpListener.Start();
-
 		var browserTask = StartUserSignin(options.StartUrl, cancellationToken);
 
 		try
 		{
+			var task = _gnomeshadeProtocolHandler.GetRequestContent(cancellationToken);
+
 			var timeoutTask = Task.Delay(_timeout, cancellationToken);
-			var contextTask = httpListener.GetContextAsync();
-			await Task.WhenAny(timeoutTask, contextTask);
+			await Task.WhenAny(timeoutTask, task);
 			if (timeoutTask.IsCompleted)
 			{
 				return new() { ResultType = BrowserResultType.Timeout, Error = "Timeout" };
 			}
 
-			var httpContext = contextTask.Result;
-			var result = await HandeRequest(httpContext);
-			httpContext.Response.Close();
-
+			var result = task.Result;
 			await browserTask;
 
 			return string.IsNullOrWhiteSpace(result)
@@ -70,10 +58,6 @@ public abstract class Browser : IBrowser
 		{
 			return new() { ResultType = UnknownError, Error = ex.Message };
 		}
-		finally
-		{
-			httpListener.Stop();
-		}
 	}
 
 	/// <summary>Starts the user sign-in process.</summary>
@@ -81,49 +65,4 @@ public abstract class Browser : IBrowser
 	/// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
 	/// <returns>A <see cref="Task"/> representing the user sign-in process.</returns>
 	protected abstract Task StartUserSignin(string startUrl, CancellationToken cancellationToken = default);
-
-	private static Task<string?> HandeRequest(HttpListenerContext context) => context.Request.HttpMethod switch
-	{
-		"GET" => SuccessfulResponse(context, () => Task.FromResult(context.Request.Url?.Query)),
-
-		"POST" when !context.Request.ContentType?.Equals(_formUrlEncoded, OrdinalIgnoreCase) ?? true =>
-			SetStatusCode(context, UnsupportedMediaType),
-
-		"POST" => SuccessfulResponse(context, () =>
-		{
-			using var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding);
-			return reader.ReadToEndAsync()!;
-		}),
-
-		_ => SetStatusCode(context, MethodNotAllowed),
-	};
-
-	private static async Task<string?> SuccessfulResponse(HttpListenerContext context, Func<Task<string?>> resultFunc)
-	{
-		context.Response.StatusCode = (int)OK;
-		context.Response.ContentType = "text/html";
-
-		const string resourceName = "SuccessfulResponsePage.html";
-		var contentStream = Assembly
-			.GetExecutingAssembly()
-			.GetManifestResourceStream(typeof(SystemBrowser), resourceName);
-
-		if (contentStream is null)
-		{
-			throw new MissingManifestResourceException(resourceName);
-		}
-
-		await using (contentStream)
-		{
-			await contentStream.CopyToAsync(context.Response.OutputStream);
-		}
-
-		return await resultFunc();
-	}
-
-	private static Task<string?> SetStatusCode(HttpListenerContext context, HttpStatusCode statusCode)
-	{
-		context.Response.StatusCode = (int)statusCode;
-		return Task.FromResult(default(string));
-	}
 }

--- a/source/Gnomeshade.Avalonia.Core/Authentication/IGnomeshadeProtocolHandler.cs
+++ b/source/Gnomeshade.Avalonia.Core/Authentication/IGnomeshadeProtocolHandler.cs
@@ -1,0 +1,17 @@
+﻿// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gnomeshade.Avalonia.Core.Authentication;
+
+/// <summary>Handles requests made in the gnomeshade protocol.</summary>
+public interface IGnomeshadeProtocolHandler
+{
+	/// <summary>Gets the content of a gnomeshade protocol request.</summary>
+	/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+	/// <returns>The request content.</returns>
+	Task<string> GetRequestContent(CancellationToken cancellationToken = default);
+}

--- a/source/Gnomeshade.Avalonia.Core/Authentication/SystemBrowser.cs
+++ b/source/Gnomeshade.Avalonia.Core/Authentication/SystemBrowser.cs
@@ -14,9 +14,10 @@ namespace Gnomeshade.Avalonia.Core.Authentication;
 public sealed class SystemBrowser : Browser
 {
 	/// <summary>Initializes a new instance of the <see cref="SystemBrowser"/> class.</summary>
+	/// <param name="gnomeshadeProtocolHandler">Handler for gnomeshade protocol requests.</param>
 	/// <param name="timeout">The time to wait until user completes signin.</param>
-	public SystemBrowser(TimeSpan timeout)
-		: base(timeout)
+	public SystemBrowser(IGnomeshadeProtocolHandler gnomeshadeProtocolHandler, TimeSpan timeout)
+		: base(gnomeshadeProtocolHandler, timeout)
 	{
 	}
 

--- a/source/Gnomeshade.Avalonia.Core/Configuration/OidcOptions.cs
+++ b/source/Gnomeshade.Avalonia.Core/Configuration/OidcOptions.cs
@@ -24,9 +24,11 @@ public sealed class OidcOptions
 	public string? ClientSecret { get; set; }
 
 	/// <inheritdoc cref="OidcClientOptions.RedirectUri"/>
-	public Uri RedirectUri => new("http://localhost:8297");
+	[Required]
+	public Uri RedirectUri { get; set; } = null!;
 
 	/// <inheritdoc cref="OidcClientOptions.Scope"/>
+	[Required]
 	public string Scope => "openid profile";
 
 	/// <summary>Gets or sets the time in seconds to wait until OIDC signin is completed by the user.</summary>

--- a/source/Gnomeshade.Desktop.Installer/Product.wxs
+++ b/source/Gnomeshade.Desktop.Installer/Product.wxs
@@ -36,6 +36,7 @@
 			<ComponentGroupRef Id="ProductComponents"/>
 			<ComponentRef Id="ApplicationShortcut"/>
 			<ComponentRef Id="ComponentDesktopShortcut"/>
+			<ComponentRef Id="RegistryEntries" />
 		</Feature>
 	</Product>
 
@@ -66,7 +67,7 @@
 			<Component Id="Gnomeshade.Desktop.exe" Guid="*">
 				<File Id="Gnomeshade.Desktop.exe" Name="Gnomeshade.Desktop.exe"
 					  Source="$(var.BuildDir)Gnomeshade.Desktop.exe"/>
-				
+
 				<RemoveFile Id="ALLFILES" Name="*.*" On="both"/>
 				<RemoveFolder Id="INSTALLFOLDER" On="both"/>
 			</Component>
@@ -117,6 +118,20 @@
 				<RemoveFolder Id="RemoveDesktopFolder" Directory="DesktopFolder" On="uninstall"/>
 				<RegistryValue Root="HKCU" Key="Software\$(var.Name)"
 							   Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+			</Component>
+		</DirectoryRef>
+	</Fragment>
+
+	<Fragment>
+		<DirectoryRef Id="TARGETDIR">
+			<Component Id="RegistryEntries" Guid="*">
+				<RegistryKey Root="HKCU" Key="SOFTWARE\Classes\gnomeshade" Action="createAndRemoveOnUninstall">
+					<RegistryValue Type="string" Value="URL:gnomeshade"/>
+					<RegistryValue Type="string" Value="" Name="URL Protocol" KeyPath="yes"/>
+					<RegistryKey Key="shell\open\command" Action="createAndRemoveOnUninstall">
+						<RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]Gnomeshade.Desktop.exe&quot; &quot;%1&quot;"/>
+					</RegistryKey>
+				</RegistryKey>
 			</Component>
 		</DirectoryRef>
 	</Fragment>

--- a/source/Gnomeshade.Desktop/App.axaml.cs
+++ b/source/Gnomeshade.Desktop/App.axaml.cs
@@ -14,6 +14,7 @@ using Avalonia.Markup.Xaml;
 using Gnomeshade.Avalonia.Core;
 using Gnomeshade.Avalonia.Core.Authentication;
 using Gnomeshade.Avalonia.Core.Configuration;
+using Gnomeshade.Desktop.Authentication;
 using Gnomeshade.Desktop.Views;
 using Gnomeshade.WebApi.Client;
 
@@ -67,10 +68,12 @@ public sealed class App : Application
 		serviceCollection
 			.AddSingleton<IClock>(SystemClock.Instance)
 			.AddSingleton(DateTimeZoneProviders.Tzdb)
+			.AddSingleton<IGnomeshadeProtocolHandler, WindowsProtocolHandler>()
 			.AddSingleton<IBrowser, SystemBrowser>(provider =>
 			{
+				var protocolHandler = provider.GetRequiredService<IGnomeshadeProtocolHandler>();
 				var options = provider.GetRequiredService<IOptionsMonitor<OidcOptions>>().CurrentValue;
-				return new(options.SigninTimeout);
+				return new(protocolHandler, options.SigninTimeout);
 			});
 
 		serviceCollection.AddTransient<OidcClient>(provider =>

--- a/source/Gnomeshade.Desktop/Authentication/WindowsProtocolHandler.cs
+++ b/source/Gnomeshade.Desktop/Authentication/WindowsProtocolHandler.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Gnomeshade.Avalonia.Core.Authentication;
+
+namespace Gnomeshade.Desktop.Authentication;
+
+/// <inheritdoc />
+public sealed class WindowsProtocolHandler : IGnomeshadeProtocolHandler
+{
+	internal const string Name = "gnomeshade";
+
+	/// <inheritdoc />
+	public async Task<string> GetRequestContent(CancellationToken cancellationToken = default)
+	{
+		await using var pipeServer = new NamedPipeServerStream(Name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+		await pipeServer.WaitForConnectionAsync(cancellationToken);
+
+		var streamReader = new StreamReader(pipeServer);
+		var value = await streamReader.ReadToEndAsync();
+
+		var uri = new Uri(value, UriKind.Absolute);
+		return uri.Query;
+	}
+}

--- a/source/Gnomeshade.Desktop/appsettings.json
+++ b/source/Gnomeshade.Desktop/appsettings.json
@@ -1,12 +1,11 @@
 {
-  "Gnomeshade": {
-    "BaseAddress": "https://localhost:5001/api/v1.0/"
-  },
-  "Oidc": {
-    "Authority": "",
-    "ClientId": "gnomeshade-desktop",
-    "ClientSecret": "",
-    "RedirectUri": "http://localhost:8297",
-    "Scope": "openid profile"
-  }
+	"Gnomeshade": {
+		"BaseAddress": "https://localhost:5001/api/v1.0/"
+	},
+	"Oidc": {
+		"Authority": "",
+		"ClientId": "gnomeshade-desktop",
+		"ClientSecret": "",
+		"RedirectUri": "gnomeshade://localhost"
+	}
 }

--- a/tests/Gnomeshade.WebApi.Tests.Integration/AuthorizationTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/AuthorizationTests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
+using Gnomeshade.Avalonia.Core.Authentication;
 using Gnomeshade.WebApi.Client;
 using Gnomeshade.WebApi.Tests.Integration.Fixtures;
 
@@ -41,16 +42,18 @@ public sealed class AuthorizationTests : WebserverTests
 	{
 		var services = new ServiceCollection();
 
+		var redirectUri = $"http://localhost:{Fixture.RedirectPort}/";
 		services
 			.AddHttpClient()
 			.AddLogging()
 			.AddSingleton<IBrowser, MockBrowser>()
+			.AddSingleton<IGnomeshadeProtocolHandler, MockProtocolHandler>(_ => new(redirectUri))
 			.AddTransient<OidcClient>(provider => new(new()
 			{
 				Authority = $"http://localhost:{Fixture.KeycloakPort}/realms/gnomeshade/",
 				ClientId = "gnomeshade",
 				Scope = "openid profile",
-				RedirectUri = $"http://localhost:{Fixture.RedirectPort}/",
+				RedirectUri = redirectUri,
 				Browser = provider.GetRequiredService<IBrowser>(),
 				LoggerFactory = provider.GetRequiredService<ILoggerFactory>(),
 				HttpClientFactory = _ => provider.GetRequiredService<HttpClient>(),

--- a/tests/Gnomeshade.WebApi.Tests.Integration/MockBrowser.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/MockBrowser.cs
@@ -19,8 +19,8 @@ internal sealed class MockBrowser : Browser
 {
 	private readonly HttpClient _httpClient;
 
-	public MockBrowser(HttpClient httpClient)
-		: base(TimeSpan.FromMinutes(1))
+	public MockBrowser(IGnomeshadeProtocolHandler gnomeshadeProtocolHandler, HttpClient httpClient)
+		: base(gnomeshadeProtocolHandler, TimeSpan.FromMinutes(1))
 	{
 		_httpClient = httpClient;
 	}

--- a/tests/Gnomeshade.WebApi.Tests.Integration/MockProtocolHandler.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/MockProtocolHandler.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Gnomeshade.Avalonia.Core.Authentication;
+
+using static System.Net.HttpStatusCode;
+
+namespace Gnomeshade.WebApi.Tests.Integration;
+
+internal sealed class MockProtocolHandler : IGnomeshadeProtocolHandler
+{
+	private readonly string _uriPrefix;
+
+	public MockProtocolHandler(string uriPrefix)
+	{
+		_uriPrefix = uriPrefix;
+	}
+
+	public async Task<string> GetRequestContent(CancellationToken cancellationToken = default)
+	{
+		using var httpListener = new HttpListener();
+		httpListener.Prefixes.Add(_uriPrefix);
+		httpListener.Start();
+
+		var context = await httpListener.GetContextAsync();
+		var result = HandeRequest(context);
+		context.Response.Close();
+
+		return result;
+	}
+
+	private static string HandeRequest(HttpListenerContext context) => context.Request.HttpMethod switch
+	{
+		"GET" => SetStatusCode(context, NoContent, context.Request.Url?.Query),
+		_ => SetStatusCode(context, MethodNotAllowed),
+	};
+
+	private static string SetStatusCode(HttpListenerContext context, HttpStatusCode statusCode, string? result = default)
+	{
+		context.Response.StatusCode = (int)statusCode;
+		return result ?? string.Empty;
+	}
+}


### PR DESCRIPTION
Changes proposed in this pull request:
* Use `gnomeshade://` scheme for OAuth redirects instead of http
