### PR TITLE
Fix trimming in .NET 7

### DIFF
--- a/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
+++ b/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
@@ -4,13 +4,7 @@
 		<OutputType>WinExe</OutputType>
 		<RuntimeIdentifiers>win10-x64;linux-x64</RuntimeIdentifiers>
 
-		<PublishTrimmed>true</PublishTrimmed>
-		<TrimMode>copyused</TrimMode>
-		<!--See https://github.com/dotnet/linker/issues/3039-->
-		<_TrimmerDefaultAction>copy</_TrimmerDefaultAction>
-		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
-		<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+		<PublishTrimmed>false</PublishTrimmed>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
@@ -49,9 +43,5 @@
 		<None Include="Assets\avalonia-logo.ico">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-	</ItemGroup>
-
-	<ItemGroup>
-		<TrimmerRootAssembly Include="mscorlib" />
 	</ItemGroup>
 </Project>

--- a/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -182,7 +182,8 @@ public sealed class Register : PageModel
 		/// <summary>Gets or sets the password confirmation value.</summary>
 		[DataType(DataType.Password)]
 		[Display(Name = "Confirm password")]
-		[Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+		[Compare(nameof(Password), ErrorMessage = "The password and confirmation password do not match.")]
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Unused otherProperty will have it's own warning")]
 		public string ConfirmPassword { get; set; } = null!;
 	}
 }

--- a/source/Gnomeshade.WebApi/Configuration/ConfigurationExtensions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/ConfigurationExtensions.cs
@@ -11,6 +11,8 @@ using JetBrains.Annotations;
 
 using Microsoft.Extensions.Configuration;
 
+using static System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
+
 using static JetBrains.Annotations.ImplicitUseKindFlags;
 using static JetBrains.Annotations.ImplicitUseTargetFlags;
 
@@ -18,7 +20,7 @@ namespace Gnomeshade.WebApi.Configuration;
 
 internal static class ConfigurationExtensions
 {
-	internal static bool GetValidIfDefined<[MeansImplicitUse(Assign, Members)] TOptions>(
+	internal static bool GetValidIfDefined<[MeansImplicitUse(Assign, Members)] [DynamicallyAccessedMembers(All)] TOptions>(
 		this IConfiguration configuration,
 		[MaybeNullWhen(false)] out TOptions options)
 		where TOptions : notnull, new()
@@ -33,14 +35,16 @@ internal static class ConfigurationExtensions
 		return true;
 	}
 
-	internal static TOptions GetValid<[MeansImplicitUse(Assign, Members)] TOptions>(this IConfiguration configuration)
+	internal static TOptions GetValid<[MeansImplicitUse(Assign, Members)] [DynamicallyAccessedMembers(All)] TOptions>(
+		this IConfiguration configuration)
 		where TOptions : notnull, new()
 	{
 		var sectionName = typeof(TOptions).GetSectionName();
 		return configuration.GetValid<TOptions>(sectionName);
 	}
 
-	internal static TOptions GetValid<[MeansImplicitUse(Assign, Members)] TOptions>(
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"{nameof(DynamicallyAccessedMembersAttribute)} indicates what is dynamically accessed")]
+	internal static TOptions GetValid<[MeansImplicitUse(Assign, Members)] [DynamicallyAccessedMembers(All)] TOptions>(
 		this IConfiguration configuration,
 		string sectionName)
 		where TOptions : notnull, new()
@@ -61,7 +65,9 @@ internal static class ConfigurationExtensions
 		return configuration.GetChildren().Any(section => section.Key == sectionName);
 	}
 
-	private static TOptions ValidateAndThrow<TOptions>(this TOptions options)
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"{nameof(DynamicallyAccessedMembersAttribute)} indicates what is dynamically accessed")]
+	private static TOptions ValidateAndThrow<[DynamicallyAccessedMembers(PublicProperties)] TOptions>(
+		this TOptions options)
 		where TOptions : notnull
 	{
 		Validator.ValidateObject(options, new(options), true);

--- a/source/Gnomeshade.WebApi/Configuration/Options/ElasticSearchLoggingOptions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/Options/ElasticSearchLoggingOptions.cs
@@ -3,8 +3,10 @@
 // See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Gnomeshade.WebApi.Configuration.Options;
 
@@ -14,6 +16,7 @@ public sealed class ElasticSearchLoggingOptions
 	/// <summary>Gets the ElasticSearch nodes to which to log to.</summary>
 	[Required]
 	[MinLength(1)]
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"Implements {nameof(ICollection)}")]
 	public List<Uri> Nodes { get; init; } = null!;
 
 	/// <summary>Gets the username to use for basic authentication.</summary>

--- a/source/Gnomeshade.WebApi/Configuration/Options/TlsOptions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/Options/TlsOptions.cs
@@ -2,8 +2,10 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 
@@ -16,6 +18,7 @@ public sealed record TlsOptions : IValidatableObject
 	/// <seealso href="https://github.com/dotnet/runtime/issues/23818#issuecomment-482764511"/>
 	[Required]
 	[MinLength(1)]
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"Implements {nameof(ICollection)}")]
 	public List<TlsCipherSuite> CipherSuites { get; init; } = null!;
 
 	/// <inheritdoc />

--- a/source/Gnomeshade.WebApi/Configuration/SerilogHostConfiguration.cs
+++ b/source/Gnomeshade.WebApi/Configuration/SerilogHostConfiguration.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
@@ -31,6 +32,7 @@ internal static class SerilogHostConfiguration
 		.MinimumLevel.Verbose()
 		.CreateBootstrapLogger();
 
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The type is primitive")]
 	internal static void Configure(HostBuilderContext context, LoggerConfiguration configuration)
 	{
 		configuration

--- a/source/Gnomeshade.WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -2,14 +2,19 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
+using static System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
 
 namespace Gnomeshade.WebApi.Configuration;
 
 internal static class ServiceCollectionExtensions
 {
-	internal static IServiceCollection AddValidatedOptions<TOptions>(
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"{nameof(DynamicallyAccessedMembersAttribute)} indicates what is dynamically accessed")]
+	internal static IServiceCollection AddValidatedOptions<[DynamicallyAccessedMembers(All)] TOptions>(
 		this IServiceCollection services,
 		IConfiguration configuration)
 		where TOptions : class

--- a/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
+++ b/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
@@ -3,13 +3,9 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<RuntimeIdentifiers>linux-x64;linux-musl-x64</RuntimeIdentifiers>
-
-		<PublishTrimmed>true</PublishTrimmed>
-		<TrimMode>copyused</TrimMode>
-		<!--See https://github.com/dotnet/linker/issues/3039-->
-		<_TrimmerDefaultAction>copy</_TrimmerDefaultAction>
-		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+
+		<PublishTrimmed>false</PublishTrimmed>
 
 		<NoWarn>CS8002</NoWarn>
 		<SignAssembly>true</SignAssembly>

--- a/source/Gnomeshade.WebApi/V1/Importing/Iso20022AccountReportReader.cs
+++ b/source/Gnomeshade.WebApi/V1/Importing/Iso20022AccountReportReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Xml.Serialization;
@@ -10,16 +11,13 @@ using VMelnalksnis.ISO20022DotNet.MessageSets.BankToCustomerCashManagement.V2.Ac
 
 namespace Gnomeshade.WebApi.V1.Importing;
 
-/// <summary>
-/// <see cref="BankToCustomerAccountReportV02"/> XML reader.
-/// </summary>
+/// <summary><see cref="BankToCustomerAccountReportV02"/> XML reader.</summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Unused properties can removed from models")]
 public sealed class Iso20022AccountReportReader
 {
 	private readonly XmlSerializer _xmlSerializer = new(typeof(Document));
 
-	/// <summary>
-	/// Reads the <see cref="BankToCustomerAccountReportV02"/> message from the XML stream.
-	/// </summary>
+	/// <summary>Reads the <see cref="BankToCustomerAccountReportV02"/> message from the XML stream.</summary>
 	/// <param name="inputStream">Stream of containing the message.</param>
 	/// <returns>The account report message from the stream.</returns>
 	public BankToCustomerAccountReportV02 ReadReport(Stream inputStream)


### PR DESCRIPTION
.NET 7 has removed copyused trimming mode, only partial (trim assemblies that have opted in) or full (trim all assemblies) remain. This will result in an increased application size, but copyused won't be supported anymore.