### PR TITLE
Fix working directory within docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ ENV Database__Provider="Sqlite" \
 
 VOLUME /data
 EXPOSE 80
-ENTRYPOINT ["/gnomeshade/Gnomeshade.WebApi"]
+
+WORKDIR /gnomeshade
+ENTRYPOINT ["./Gnomeshade.WebApi"]


### PR DESCRIPTION
Changes proposed in this pull request:
* Set working directory within docker container, so that all relative paths and directories, such as `appsettings.json` and `wwwroot`, work correctly
