### PR TITLE
Fix parsing of Rimi receipts

### DIFF
--- a/Gnomeshade.sln.DotSettings
+++ b/Gnomeshade.sln.DotSettings
@@ -13,6 +13,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lockbox/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nordigen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ownable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rimi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Servicer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upserted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upsertion/@EntryIndexedValue">True</s:Boolean>

--- a/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
+++ b/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
@@ -56,7 +56,7 @@
 		<ProjectReference Include="..\Gnomeshade.WebApi.Models\Gnomeshade.WebApi.Models.csproj" />
 	</ItemGroup>
 
-	<Target Name="JavascriptLibraries" BeforeTargets="Build">
+	<Target Name="JavascriptLibraries" BeforeTargets="Build" Condition="'$(ContinuousIntegrationBuild)' == 'true'">
 		<Exec WorkingDirectory="./Node" Command="npm ci" />
 		<Exec WorkingDirectory="./Node" Command="node ./node_modules/gulp/bin/gulp.js build" />
 	</Target>

--- a/source/Gnomeshade.WebApi/V1/Importing/Paperless/Parsing/RimiReceiptParser.cs
+++ b/source/Gnomeshade.WebApi/V1/Importing/Paperless/Parsing/RimiReceiptParser.cs
@@ -23,8 +23,8 @@ public sealed class RimiReceiptParser : IPaperlessDocumentParser
 		("_", " "),
 		("é", "ē"),
 		("°", string.Empty),
-		("’", string.Empty),
-		("'", string.Empty),
+		("’", " "),
+		("'", " "),
 		("\"", string.Empty),
 	};
 
@@ -41,7 +41,7 @@ public sealed class RimiReceiptParser : IPaperlessDocumentParser
 	{
 		"Atl. ",
 		"Atl ",
-		"ati",
+		"ati ",
 	};
 
 	private readonly ILogger<RimiReceiptParser> _logger;
@@ -72,6 +72,12 @@ public sealed class RimiReceiptParser : IPaperlessDocumentParser
 		}
 
 		var productPart = content[start..end].Trim('\n');
+		var startIndex = productPart.IndexOf("KLIENT", StringComparison.Ordinal);
+		if (startIndex >= 0)
+		{
+			var newStart = productPart.IndexOf("\n", startIndex + 6, StringComparison.Ordinal);
+			productPart = productPart[newStart..].TrimStart('\n');
+		}
 
 		_logger.LogDebug("Extracted products from document content {ProductPart}", productPart);
 
@@ -94,7 +100,7 @@ public sealed class RimiReceiptParser : IPaperlessDocumentParser
 
 			// Check if next line contains discounted price
 			if (index != lines.Count - 1 &&
-				_discountIdentifiers.Any(identifier => lines[index + 1].Contains(identifier, _comparison)))
+				_discountIdentifiers.Any(identifier => lines[index + 1].StartsWith(identifier, _comparison)))
 			{
 				index++;
 			}

--- a/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Identification/PurchaseIdentifierTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Identification/PurchaseIdentifierTests.cs
@@ -1,0 +1,43 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+
+using Gnomeshade.Data.Entities;
+using Gnomeshade.WebApi.V1.Importing.Paperless.Identification;
+
+namespace Gnomeshade.WebApi.Tests.V1.Importing.Paperless.Identification;
+
+public sealed class PurchaseIdentifierTests
+{
+	private static readonly Guid _kilogramId = Guid.NewGuid();
+	private static readonly Guid _gramId = Guid.NewGuid();
+
+	private readonly ProductEntity[] _products =
+	{
+		new() { Name = "Tostermaize franču Brioche", UnitId = _gramId },
+	};
+
+	private readonly CurrencyEntity[] _currencies =
+	{
+		new() { AlphabeticCode = "EUR" },
+	};
+
+	private readonly UnitEntity[] _units =
+	{
+		new() { Name = "Gram", Symbol = "g", Id = _gramId },
+		new() { Name = "Kilogram", Symbol = "kg", Id = _kilogramId },
+	};
+
+	[TestCaseSource(typeof(RimiPurchaseIdentifierTestCaseSource))]
+	public void IdentifyPurchase_ShouldReturnExpected(
+		IPurchaseIdentifier identifier,
+		string purchaseText,
+		IdentifiedPurchase expectedPurchase)
+	{
+		var purchase = identifier.IdentifyPurchase(purchaseText, _products, _currencies, _units);
+
+		purchase.Should().BeEquivalentTo(expectedPurchase);
+	}
+}

--- a/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Identification/RimiPurchaseIdentifierTestCaseSource.cs
+++ b/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Identification/RimiPurchaseIdentifierTestCaseSource.cs
@@ -1,0 +1,53 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Gnomeshade.WebApi.V1.Importing.Paperless.Identification;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Gnomeshade.WebApi.Tests.V1.Importing.Paperless.Identification;
+
+[SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Contains test data")]
+public sealed class RimiPurchaseIdentifierTestCaseSource : IEnumerable<TestCaseData>
+{
+	public IEnumerator<TestCaseData> GetEnumerator()
+	{
+		var identifier = new RimiPurchaseIdentifier(NullLogger<RimiPurchaseIdentifier>.Instance);
+
+		yield return new TestCaseData(
+				identifier,
+				@"Tostermaize franēu
+Brioche 450g
+1 gab x 2,55 EUR 2,55 8",
+				new IdentifiedPurchase(
+					"Tostermaize franēu Brioche 450g",
+					"Tostermaize franču Brioche",
+					88,
+					"EUR",
+					2.55m,
+					450,
+					"g"))
+			.SetName("Existing product");
+
+		yield return new TestCaseData(
+				identifier,
+				@"siefs Dor blu 50% kg
+Or 188 kg X 14,59 EUR/kg 2,748",
+				new IdentifiedPurchase(
+					"siefs Dor blu 50% kg",
+					"Tostermaize franču Brioche",
+					30,
+					"EUR",
+					2.74m,
+					188,
+					null))
+			.SetName("New product");
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Parsing/PaperlessDocumentParserTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Parsing/PaperlessDocumentParserTests.cs
@@ -1,0 +1,25 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using Gnomeshade.WebApi.V1.Importing.Paperless.Parsing;
+
+using VMelnalksnis.PaperlessDotNet.Documents;
+
+namespace Gnomeshade.WebApi.Tests.V1.Importing.Paperless.Parsing;
+
+public sealed class PaperlessDocumentParserTests
+{
+	[TestCaseSource(typeof(RimiReceiptParserTestCaseSource))]
+	public void ParsePurchases_ShouldReturnExpected(
+		IPaperlessDocumentParser parser,
+		Document document,
+		List<string> expectedPurchases)
+	{
+		var purchases = parser.ParsePurchases(document);
+
+		purchases.Should().BeEquivalentTo(expectedPurchases);
+	}
+}

--- a/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Parsing/RimiReceiptParserTestCaseSource.cs
+++ b/tests/Gnomeshade.WebApi.Tests/V1/Importing/Paperless/Parsing/RimiReceiptParserTestCaseSource.cs
@@ -1,0 +1,224 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Gnomeshade.WebApi.V1.Importing.Paperless.Parsing;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using VMelnalksnis.PaperlessDotNet.Documents;
+
+namespace Gnomeshade.WebApi.Tests.V1.Importing.Paperless.Parsing;
+
+[SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Contains test data")]
+public sealed class RimiReceiptParserTestCaseSource : IEnumerable<TestCaseData>
+{
+	public IEnumerator<TestCaseData> GetEnumerator()
+	{
+		var parser = new RimiReceiptParser(NullLogger<RimiReceiptParser>.Instance);
+
+		var standardProductPart = @"Tualetes papire Zewa Delicate
+Care, gab
+
+1 gab X 4,99 EUR 4,99 8
+Atl -2,00 Gala cena 2,99
+Tostermaize franéu
+
+Brioche 450g
+
+1 gab x 2,55 EUR 2,55 8
+
+Sviests Exporta 82,5% 200g
+
+1 gab X 3,09 EUR 3,09 A
+Atl -0,50 Gala cena 2,59
+
+Sviests Smltene 82% 200g
+
+1 gab X 2,99 EUR 2,99 8".ReplaceLineEndings("\n");
+
+		var expectedProducts = new List<string>
+		{
+			@"Tualetes papire Zewa Delicate
+Care, gab
+1 gab X 4,99 EUR 4,99 8
+Atl -2,00 Gala cena 2,99",
+
+			@"Tostermaize franēu
+Brioche 450g
+1 gab x 2,55 EUR 2,55 8",
+
+			@"Sviests Exporta 82,5% 200g
+1 gab X 3,09 EUR 3,09 A
+Atl -0,50 Gala cena 2,59",
+
+			@"Sviests Smltene 82% 200g
+1 gab X 2,99 EUR 2,99 8",
+		};
+
+		yield return new TestCaseData(
+				parser,
+				new Document
+				{
+					Content = $@"RimilY
+
+Katra diena arvien labaka
+
+SIA RIME LATVIA
+Jur adrese Riga, A Deglava iela 161
+Rimi Super Agenskalns (Riga)
+
+Kase Nr 33,
+
+PVN makeataja numurs LVv40001234567
+Sasijas mymurs SP-LVO0123
+Ceks —
+Elektroniska izdruka
+GOCHNRCOCONGNONE S16
+
+
+
+
+
+KLIENTS
+
+
+
+{standardProductPart}
+
+
+
+
+
+ATLALDES
+
+Tualetes papirs Zewa Delicate
+Care, 8gab -2,00
+Izmantota Mans Rim nauda -0,81
+Citas akerjas =1) 66
+
+
+
+Tavs 1etaupijuns 6,21
+
+
+
+Makeajanu karte
+Apnakaa
+
+BEZKONTAKTA KARTE
+VISA BEZKONTAKTA
+
+BANKAS KVITS NR 123456
+TERMINALA ID 12345678
+TIRGOPAJA ID 1234567
+LALKS 2020-01-13 12 59 58".ReplaceLineEndings("\n"),
+				},
+				expectedProducts)
+			.SetName("Multiple newline groups before products");
+
+		yield return new TestCaseData(
+				parser,
+				new Document
+				{
+					Content = $@"RimiV
+
+Katra diena arvien tabaka
+
+SIA RIME LATVIA
+Jur. adrese “Riga, A. Deglava iela 161
+Rimi Super Agenskalns (Riga)
+
+Kase Nr. 31
+
+PVN _maksataja numurs. LVv40001234567
+Sasijas nymure: SP-LVO0123
+= Ceks —
+= Elektromiska izdruka
+KLIENTS. YXOCCCOOOORIOKE S16
+
+
+
+
+
+{standardProductPart}
+
+
+
+ATLALDES
+Citas akcijas
+
+
+
+
+
+
+Tavs 1etaupijuns
+
+Maksajumu karte
+Apnakaa
+BEZKONTAKTA KARTE
+VISA BEZKONTAKTA
+
+BANKAS KVITS NR 123456
+TERMINALA ID 12345678
+TIRGOPAJA ID 1234567
+LALKS 2020-01-13 12 59 58".ReplaceLineEndings("\n"),
+				},
+				expectedProducts)
+			.SetName("Single newline group before products");
+
+		yield return new TestCaseData(
+				parser,
+				new Document
+				{
+					Content = $@"RimivV
+Katra diena arvien labaka
+
+SIA RIME LATVIA
+Jur. adrese: Riga, A. Deglava iela 161
+Rimi Super Agenskalns (Riga)
+
+Kase Nr. 35
+
+PVN makeataja nunurs: LVv40001234567
+Sasijas nymurs: SP-LVO0123
+Ceks —
+Elektroniska izdruka
+OOOCCCOOOOGIOKES 16
+
+
+
+
+
+
+
+{standardProductPart}
+ATLALDES
+
+Tamantota Mans Rimi nauda -1,31
+Gites akes jas 27138
+Tavs 1etaupijuns 8,59
+
+
+
+Makeajumu karte
+Apnaksa
+BEZKONTAKTA KARTE
+VISA BEZKONTAKTA
+
+BBANKAS KVITS NR 123456
+TERMINALA ID 12345678
+TIRGOPAJA ID 1234567
+LALKS 2020-01-13 12 59 58".ReplaceLineEndings("\n"),
+				},
+				expectedProducts)
+			.SetName("Discounts immediately after products");
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}


### PR DESCRIPTION
Changes proposed in this pull request:
* Don't run `npm ci` on each local build
* Improve parsing of receipts
