### PR TITLE
Fix category report handling of currencies in simple cases

### DIFF
--- a/source/Gnomeshade.Avalonia.Core/Reports/ProductReportViewModel.cs
+++ b/source/Gnomeshade.Avalonia.Core/Reports/ProductReportViewModel.cs
@@ -268,7 +268,7 @@ public sealed partial class ProductReportViewModel : ViewModelBase
 
 		Series.Add(new()
 		{
-			Values = calculationFunction.Update(dateTimePoints),
+			Values = calculationFunction.Update(dateTimePoints).ToArray(),
 			Stroke = null,
 			DataLabelsPaint = new SolidColorPaint(new(255, 255, 255)),
 			DataLabelsSize = 12,


### PR DESCRIPTION


Changes proposed in this pull request:
* Resolves simple cases for #686 
* Fixes performance issue in `CategoryReportViewModel` by calling `ToArray` for series values
