### PR TITLE
fix(desktop): Split bootstrap and application logs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,6 +67,7 @@
 		<PackageVersion Include="Serilog" Version="2.12.0"/>
 		<PackageVersion Include="Serilog.AspNetCore" Version="6.1.0"/>
 		<PackageVersion Include="Serilog.Extensions.Hosting" Version="5.0.1"/>
+		<PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0"/>
 		<PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0"/>
 		<PackageVersion Include="Serilog.Sinks.Elasticsearch" Version="9.0.0"/>
 		<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0"/>

--- a/source/Gnomeshade.Desktop/App.axaml.cs
+++ b/source/Gnomeshade.Desktop/App.axaml.cs
@@ -42,6 +42,7 @@ public sealed class App : Application
 	private static readonly ProductInfoHeaderValue _userAgent;
 
 	private readonly IServiceProvider _serviceProvider;
+	private readonly ILogger<App> _logger;
 
 	static App()
 	{
@@ -59,7 +60,9 @@ public sealed class App : Application
 			.Build();
 
 		var serviceCollection = new ServiceCollection();
-		serviceCollection.AddLogging(builder => builder.AddSerilog());
+		serviceCollection.AddLogging(builder => builder
+			.ClearProviders()
+			.AddSerilog(SerilogConfiguration.CreateLogger(configuration), true));
 
 		serviceCollection
 			.AddGnomeshadeOptions(configuration)
@@ -106,6 +109,7 @@ public sealed class App : Application
 			.AddSingleton<IDialogService, DialogService>();
 
 		_serviceProvider = serviceCollection.BuildServiceProvider();
+		_logger = _serviceProvider.GetRequiredService<ILogger<App>>();
 	}
 
 	/// <inheritdoc />
@@ -131,7 +135,7 @@ public sealed class App : Application
 	/// <inheritdoc />
 	protected override void LogBindingError(AvaloniaProperty property, Exception exception)
 	{
-		Log.Error(exception, "Failed to bind property {PropertyName} from owner type {OwnerTypeName}", property.Name, property.OwnerType.Name);
+		_logger.LogError(exception, "Failed to bind property {PropertyName} from owner type {OwnerTypeName}", property.Name, property.OwnerType.Name);
 		base.LogBindingError(property, exception);
 	}
 }

--- a/source/Gnomeshade.Desktop/Authentication/WindowsProtocolHandler.cs
+++ b/source/Gnomeshade.Desktop/Authentication/WindowsProtocolHandler.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 
 using Gnomeshade.Avalonia.Core.Authentication;
 
+using Microsoft.Extensions.Logging;
+
 namespace Gnomeshade.Desktop.Authentication;
 
 /// <inheritdoc />
@@ -19,15 +21,27 @@ public sealed class WindowsProtocolHandler : IGnomeshadeProtocolHandler
 {
 	internal const string Name = "gnomeshade";
 
+	private readonly ILogger<WindowsProtocolHandler> _logger;
+
+	/// <summary>Initializes a new instance of the <see cref="WindowsProtocolHandler"/> class.</summary>
+	/// <param name="logger">Logger for logging in the specified category.</param>
+	public WindowsProtocolHandler(ILogger<WindowsProtocolHandler> logger)
+	{
+		_logger = logger;
+	}
+
 	/// <inheritdoc />
 	public async Task<string> GetRequestContent(CancellationToken cancellationToken = default)
 	{
+		_logger.LogDebug("Starting named pipe server");
 		await using var pipeServer = new NamedPipeServerStream(Name, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
 		await pipeServer.WaitForConnectionAsync(cancellationToken);
 
+		_logger.LogInformation("Connection with client established, reading content");
 		var streamReader = new StreamReader(pipeServer);
-		var value = await streamReader.ReadToEndAsync();
+		var value = await streamReader.ReadToEndAsync(cancellationToken);
 
+		_logger.LogDebug("Received content from named pipe");
 		var uri = new Uri(value, UriKind.Absolute);
 		return uri.Query;
 	}

--- a/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
+++ b/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
 		<PackageReference Include="Serilog" />
 		<PackageReference Include="Serilog.Extensions.Hosting" />
+		<PackageReference Include="Serilog.Settings.Configuration" />
 		<PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="Serilog.Sinks.Trace" />
 	</ItemGroup>

--- a/source/Gnomeshade.Desktop/Program.cs
+++ b/source/Gnomeshade.Desktop/Program.cs
@@ -31,7 +31,7 @@ internal static class Program
 {
 	public static void Main(string[] args)
 	{
-		InitializeBootstrapLogger();
+		SerilogConfiguration.InitializeBootstrapLogger();
 		if (AnotherInstanceIsRunning())
 		{
 			SendArgumentsToRunningInstance(args);
@@ -71,25 +71,16 @@ internal static class Program
 				.LogToTrace(LogEventLevel.Debug);
 	}
 
-	private static void InitializeBootstrapLogger()
-	{
-		Serilog.Debugging.SelfLog.Enable(output => Debug.WriteLine(output));
-		Log.Logger = new LoggerConfiguration()
-			.Enrich.FromLogContext()
-			.WriteTo.Trace()
-			.WriteTo.File("bootstrap_log")
-			.MinimumLevel.Debug()
-			.CreateBootstrapLogger();
-	}
-
 	[SupportedOSPlatform("windows")]
 	private static bool AnotherInstanceIsRunning()
 	{
+		Log.Debug("Checking if another instance is running");
 		return EventWaitHandle.TryOpenExisting(WindowsProtocolHandler.Name, out _);
 	}
 
 	private static void SendArgumentsToRunningInstance(IEnumerable<string> args)
 	{
+		Log.Debug("Sending arguments to an already running instance");
 		using var pipeClient = new NamedPipeClientStream(".", WindowsProtocolHandler.Name);
 		pipeClient.Connect((int)TimeSpan.FromSeconds(5).TotalMilliseconds);
 
@@ -101,6 +92,7 @@ internal static class Program
 	[SupportedOSPlatform("windows")]
 	private static IDisposable GetApplicationHandle()
 	{
+		Log.Debug("Getting an application handle");
 		return new EventWaitHandle(false, EventResetMode.AutoReset, WindowsProtocolHandler.Name);
 	}
 }

--- a/source/Gnomeshade.Desktop/SerilogConfiguration.cs
+++ b/source/Gnomeshade.Desktop/SerilogConfiguration.cs
@@ -1,0 +1,47 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System.Diagnostics;
+
+using Microsoft.Extensions.Configuration;
+
+using Serilog;
+
+namespace Gnomeshade.Desktop;
+
+internal static class SerilogConfiguration
+{
+	private const string _boostrapLogPath = "bootstrap.log";
+	private const string _applicationLogPath = "application.log";
+	private const int _fileSizeLimit = 10 * 1024 * 1024;
+	private const int _fileCountLimit = 2;
+
+	internal static void InitializeBootstrapLogger()
+	{
+		Serilog.Debugging.SelfLog.Enable(output => Debug.WriteLine(output));
+
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Verbose()
+			.Enrich.FromLogContext()
+			.WriteTo.Trace()
+			.WriteTo.File(
+				_boostrapLogPath,
+				shared: true,
+				fileSizeLimitBytes: _fileSizeLimit,
+				rollOnFileSizeLimit: true,
+				retainedFileCountLimit: _fileCountLimit)
+			.CreateBootstrapLogger();
+	}
+
+	internal static ILogger CreateLogger(IConfiguration configuration) => new LoggerConfiguration()
+		.MinimumLevel.Information()
+		.ReadFrom.Configuration(configuration)
+		.Enrich.FromLogContext()
+		.WriteTo.File(
+			_applicationLogPath,
+			fileSizeLimitBytes: _fileSizeLimit,
+			rollOnFileSizeLimit: true,
+			retainedFileCountLimit: _fileCountLimit)
+		.CreateLogger();
+}

--- a/source/Gnomeshade.Desktop/packages.lock.json
+++ b/source/Gnomeshade.Desktop/packages.lock.json
@@ -103,6 +103,17 @@
           "Serilog.Extensions.Logging": "3.1.0"
         }
       },
+      "Serilog.Settings.Configuration": {
+        "type": "Direct",
+        "requested": "[3.4.0, )",
+        "resolved": "3.4.0",
+        "contentHash": "ULloXSiapTb3zOWodC0G4WRDQzA5RjMEfZNZzOZpH8kC3t/lrISLblklIpKC44CX0sMDF40MnJwTIQ3pFQFs4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Serilog": "2.10.0"
+        }
+      },
       "Serilog.Sinks.File": {
         "type": "Direct",
         "requested": "[5.0.0, )",
@@ -309,6 +320,14 @@
         "contentHash": "elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "Iaectmzg9Dc4ZbKX/FurrRjgO/I8rTumL5UU+Uube6vZuGetcnXoIgTA94RthFWePhdMVm8MMhVFJZdbzMsdyQ==",
+        "dependencies": {
+          "System.Text.Json": "4.6.0"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {

--- a/source/Gnomeshade.WebApi/packages.lock.json
+++ b/source/Gnomeshade.WebApi/packages.lock.json
@@ -918,16 +918,6 @@
           "Serilog": "2.12.0"
         }
       },
-      "Serilog.Settings.Configuration": {
-        "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyModel": "3.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
-          "Serilog": "2.10.0"
-        }
-      },
       "Serilog.Sinks.Debug": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -1956,6 +1946,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.File": {

--- a/tests/Gnomeshade.Desktop.Tests/packages.lock.json
+++ b/tests/Gnomeshade.Desktop.Tests/packages.lock.json
@@ -261,6 +261,14 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0"
         }
       },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "Iaectmzg9Dc4ZbKX/FurrRjgO/I8rTumL5UU+Uube6vZuGetcnXoIgTA94RthFWePhdMVm8MMhVFJZdbzMsdyQ==",
+        "dependencies": {
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -571,6 +579,7 @@
           "Microsoft.Extensions.Configuration.Json": "[7.0.0, )",
           "Serilog": "[2.12.0, )",
           "Serilog.Extensions.Hosting": "[5.0.1, )",
+          "Serilog.Settings.Configuration": "[3.4.0, )",
           "Serilog.Sinks.File": "[5.0.0, )",
           "Serilog.Sinks.Trace": "[3.0.0, )"
         }
@@ -799,6 +808,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.4.0",
+        "contentHash": "ULloXSiapTb3zOWodC0G4WRDQzA5RjMEfZNZzOZpH8kC3t/lrISLblklIpKC44CX0sMDF40MnJwTIQ3pFQFs4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "2.0.0",
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.File": {

--- a/tests/Gnomeshade.WebApi.Tests.Integration.Oidc/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.Oidc/packages.lock.json
@@ -943,16 +943,6 @@
           "Serilog": "2.12.0"
         }
       },
-      "Serilog.Settings.Configuration": {
-        "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyModel": "3.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
-          "Serilog": "2.10.0"
-        }
-      },
       "Serilog.Sinks.Debug": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -2123,6 +2113,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.Console": {

--- a/tests/Gnomeshade.WebApi.Tests.Integration.PostgreSQL/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.PostgreSQL/packages.lock.json
@@ -985,16 +985,6 @@
           "Serilog": "2.12.0"
         }
       },
-      "Serilog.Settings.Configuration": {
-        "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyModel": "3.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
-          "Serilog": "2.10.0"
-        }
-      },
       "Serilog.Sinks.Debug": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -2176,6 +2166,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.Console": {

--- a/tests/Gnomeshade.WebApi.Tests.Integration.Sqlite/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.Sqlite/packages.lock.json
@@ -985,16 +985,6 @@
           "Serilog": "2.12.0"
         }
       },
-      "Serilog.Settings.Configuration": {
-        "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyModel": "3.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
-          "Serilog": "2.10.0"
-        }
-      },
       "Serilog.Sinks.Debug": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -2176,6 +2166,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.Console": {

--- a/tests/Gnomeshade.WebApi.Tests/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests/packages.lock.json
@@ -624,16 +624,6 @@
           "Serilog": "2.12.0"
         }
       },
-      "Serilog.Settings.Configuration": {
-        "type": "Transitive",
-        "resolved": "3.3.0",
-        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyModel": "3.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
-          "Serilog": "2.10.0"
-        }
-      },
       "Serilog.Sinks.Debug": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -1623,6 +1613,17 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.1.8",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[3.4.0, )",
+        "resolved": "3.3.0",
+        "contentHash": "7GNudISZwqaT902hqEL2OFGTZeUFWfnrNLupJkOqeF41AR3GjcxX+Hwb30xb8gG2/CDXsCMVfF8o0+8KY0fJNg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "3.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "2.0.0",
+          "Serilog": "2.10.0"
         }
       },
       "Serilog.Sinks.Console": {


### PR DESCRIPTION
Changes proposed in this pull request:
* Separate bootstrap logs and application logs
* Automatically roll and delete log files based on size
