### PR TITLE
Add a linked product to categories

### DIFF
--- a/source/Gnomeshade.Avalonia.Core/Products/CategoryUpsertionViewModel.cs
+++ b/source/Gnomeshade.Avalonia.Core/Products/CategoryUpsertionViewModel.cs
@@ -31,6 +31,10 @@ public sealed partial class CategoryUpsertionViewModel : UpsertionViewModel
 	[Notify]
 	private Category? _selectedCategory;
 
+	/// <summary>Gets or sets a value indicating whether to link a product to this category for use in purchases.</summary>
+	[Notify]
+	private bool _linkProduct;
+
 	/// <summary>Gets a collection of all available categories.</summary>
 	[Notify(Setter.Private)]
 	private List<Category> _categories;
@@ -77,6 +81,7 @@ public sealed partial class CategoryUpsertionViewModel : UpsertionViewModel
 			Name = Name!,
 			Description = Description,
 			CategoryId = SelectedCategory?.Id,
+			LinkProduct = LinkProduct,
 		};
 
 		var id = Id ?? Guid.NewGuid();

--- a/source/Gnomeshade.Data/Entities/CategoryEntity.cs
+++ b/source/Gnomeshade.Data/Entities/CategoryEntity.cs
@@ -33,4 +33,7 @@ public sealed record CategoryEntity : Entity, IOwnableEntity, IModifiableEntity,
 
 	/// <summary>Gets or sets the id of the <see cref="CategoryEntity"/> for the category of this category.</summary>
 	public Guid? CategoryId { get; set; }
+
+	/// <summary>Gets or sets the id of the <see cref="ProductEntity"/> that represents this category in purchases.</summary>
+	public Guid? LinkedProductId { get; set; }
 }

--- a/source/Gnomeshade.Data/Gnomeshade.Data.csproj
+++ b/source/Gnomeshade.Data/Gnomeshade.Data.csproj
@@ -18,6 +18,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Include="Migrations\00000026_linked_product.sql" />
 		<EmbeddedResource Include="Repositories\Queries\AccountInCurrency\Delete.sql" />
 		<EmbeddedResource Include="Repositories\Queries\AccountInCurrency\Insert.sql" />
 		<EmbeddedResource Include="Repositories\Queries\AccountInCurrency\Select.sql" />

--- a/source/Gnomeshade.Data/Migrations/00000026_linked_product.sql
+++ b/source/Gnomeshade.Data/Migrations/00000026_linked_product.sql
@@ -1,0 +1,2 @@
+﻿ALTER TABLE "categories"
+	ADD COLUMN "linked_product_id" uuid NULL REFERENCES products;

--- a/source/Gnomeshade.Data/Migrations/MigrationScriptNameComparer.cs
+++ b/source/Gnomeshade.Data/Migrations/MigrationScriptNameComparer.cs
@@ -1,0 +1,30 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using static System.StringSplitOptions;
+
+namespace Gnomeshade.Data.Migrations;
+
+/// <summary>Compares migration scripts by file name ignoring namespaces.</summary>
+internal sealed class MigrationScriptNameComparer : IComparer<string?>
+{
+	/// <inheritdoc />
+	public int Compare(string? x, string? y)
+	{
+		var firstName = GetFileName(x);
+		var secondName = GetFileName(y);
+
+		return StringComparer.OrdinalIgnoreCase.Compare(firstName, secondName);
+	}
+
+	private static string? GetFileName(string? filepath)
+	{
+		var parts = filepath?.Split('.', RemoveEmptyEntries | TrimEntries);
+		return parts?.Skip(parts.Length - 2).First();
+	}
+}

--- a/source/Gnomeshade.Data/Repositories/Queries/Category/Insert.sql
+++ b/source/Gnomeshade.Data/Repositories/Queries/Category/Insert.sql
@@ -1,5 +1,5 @@
 ﻿INSERT INTO categories
-	(id, owner_id, created_by_user_id, modified_by_user_id, name, normalized_name, description, category_id)
+	(id, owner_id, created_by_user_id, modified_by_user_id, name, normalized_name, description, category_id, linked_product_id)
 VALUES
-	(@Id, @OwnerId, @CreatedByUserId, @ModifiedByUserId, @Name, upper(@Name), @Description, @CategoryId)
+	(@Id, @OwnerId, @CreatedByUserId, @ModifiedByUserId, @Name, upper(@Name), @Description, @CategoryId, @LinkedProductId)
 RETURNING id;

--- a/source/Gnomeshade.Data/Repositories/Queries/Category/Select.sql
+++ b/source/Gnomeshade.Data/Repositories/Queries/Category/Select.sql
@@ -7,7 +7,8 @@
 	   c.name AS             Name,
 	   c.normalized_name     NormalizedName,
 	   c.description,
-	   c.category_id         CategoryId
+	   c.category_id         CategoryId,
+	   c.linked_product_id   LinkedProductId
 FROM categories c
 		 INNER JOIN owners ON owners.id = c.owner_id
 		 INNER JOIN ownerships ON owners.id = ownerships.owner_id

--- a/source/Gnomeshade.Data/Repositories/Queries/Category/Update.sql
+++ b/source/Gnomeshade.Data/Repositories/Queries/Category/Update.sql
@@ -1,20 +1,19 @@
-﻿WITH c AS (
-	SELECT categories.id AS id
-	FROM categories
-			 INNER JOIN owners ON owners.id = categories.owner_id
-			 INNER JOIN ownerships ON owners.id = ownerships.owner_id
-			 INNER JOIN access ON access.id = ownerships.access_id
-	WHERE categories.id = @Id
-	  AND ownerships.user_id = @OwnerId
-	  AND (access.normalized_name = 'WRITE' OR access.normalized_name = 'OWNER')
-)
+﻿WITH c AS (SELECT categories.id AS id
+		   FROM categories
+					INNER JOIN owners ON owners.id = categories.owner_id
+					INNER JOIN ownerships ON owners.id = ownerships.owner_id
+					INNER JOIN access ON access.id = ownerships.access_id
+		   WHERE categories.id = @Id
+			 AND ownerships.user_id = @OwnerId
+			 AND (access.normalized_name = 'WRITE' OR access.normalized_name = 'OWNER'))
 UPDATE categories
 SET modified_at         = CURRENT_TIMESTAMP,
 	modified_by_user_id = @ModifiedByUserId,
 	name                = @Name,
-	normalized_name     = upper(@Name),
+	normalized_name     = UPPER(@Name),
 	description         = @Description,
-	category_id         = @CategoryId
+	category_id         = @CategoryId,
+	linked_product_id   = @LinkedProductId
 FROM c
-WHERE categories.id IN (SELECT id from c)
-RETURNING (SELECT id from c);
+WHERE categories.id IN (SELECT id FROM c)
+RETURNING (SELECT id FROM c);

--- a/source/Gnomeshade.Desktop/Views/Products/CategoryUpsertionView.axaml
+++ b/source/Gnomeshade.Desktop/Views/Products/CategoryUpsertionView.axaml
@@ -12,7 +12,7 @@
 	x:CompileBindings="True"
 	x:DataType="products:CategoryUpsertionViewModel">
 
-	<Grid ColumnDefinitions="*" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+	<Grid ColumnDefinitions="*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
 		<TextBox
 			Grid.Row="0"
 			Watermark="Name" Text="{Binding Name}">
@@ -39,15 +39,16 @@
 				</DataTemplate>
 			</AutoCompleteBox.ItemTemplate>
 		</AutoCompleteBox>
+		<CheckBox Grid.Column="0" Grid.Row="3" IsChecked="{Binding LinkProduct}">Create linked product</CheckBox>
 
 		<Button
-			Grid.Column="0" Grid.Row="3"
+			Grid.Column="0" Grid.Row="4"
 			Padding="25 5"
 			IsEnabled="{Binding CanSave}" Command="{ReflectionBinding SaveAsync}">
 			Save
 		</Button>
 		<TextBlock
-			Grid.Row="4"
+			Grid.Row="5"
 			VerticalAlignment="Center"
 			Text="{Binding ErrorMessage}" />
 	</Grid>

--- a/source/Gnomeshade.WebApi.Models/Products/Category.cs
+++ b/source/Gnomeshade.WebApi.Models/Products/Category.cs
@@ -40,4 +40,7 @@ public sealed record Category
 
 	/// <summary>The id of the category to which the category belongs to.</summary>
 	public Guid? CategoryId { get; set; }
+
+	/// <summary>The id of the linked product which represents this category in purchases.</summary>
+	public Guid? LinkedProductId { get; set; }
 }

--- a/source/Gnomeshade.WebApi.Models/Products/CategoryCreation.cs
+++ b/source/Gnomeshade.WebApi.Models/Products/CategoryCreation.cs
@@ -22,4 +22,8 @@ public sealed record CategoryCreation : Creation
 
 	/// <inheritdoc cref="Category.CategoryId"/>
 	public Guid? CategoryId { get; set; }
+
+	/// <summary>Whether to create a linked product for using this category in purchases.</summary>
+	/// <seealso cref="Category.LinkedProductId"/>
+	public bool LinkProduct { get; set; }
 }

--- a/tests/Gnomeshade.WebApi.Tests.Integration/V1/Controllers/CategoriesControllerTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/V1/Controllers/CategoriesControllerTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE.txt file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ namespace Gnomeshade.WebApi.Tests.Integration.V1.Controllers;
 public sealed class CategoriesControllerTests : WebserverTests
 {
 	private IProductClient _client = null!;
+	private Guid _categoryId;
 
 	public CategoriesControllerTests(WebserverFixture fixture)
 		: base(fixture)
@@ -27,15 +29,15 @@ public sealed class CategoriesControllerTests : WebserverTests
 	public async Task SetUpAsync()
 	{
 		_client = await Fixture.CreateAuthorizedClientAsync();
+		_categoryId = Guid.NewGuid();
 	}
 
 	[Test]
 	public async Task Add_ShouldCreateExpected()
 	{
-		var categoryId = Guid.NewGuid();
-		await _client.PutCategoryAsync(categoryId, new() { Name = $"{categoryId:N}" });
+		await _client.PutCategoryAsync(_categoryId, new() { Name = $"{_categoryId:N}" });
 
-		var category = await _client.GetCategoryAsync(categoryId);
+		var category = await _client.GetCategoryAsync(_categoryId);
 		(await _client.GetCategoriesAsync())
 			.Should()
 			.ContainEquivalentOf(category);
@@ -44,19 +46,51 @@ public sealed class CategoriesControllerTests : WebserverTests
 		var otherCategoryId = Guid.NewGuid();
 		await _client.PutCategoryAsync(otherCategoryId, new() { Name = $"{otherCategoryId:N}" });
 
-		await _client.PutCategoryAsync(categoryId, new() { Name = $"{Guid.NewGuid():N}", CategoryId = otherCategoryId });
-		var updatedCategory = await _client.GetCategoryAsync(categoryId);
+		await _client.PutCategoryAsync(_categoryId, new() { Name = $"{Guid.NewGuid():N}", CategoryId = otherCategoryId });
+		var updatedCategory = await _client.GetCategoryAsync(_categoryId);
 		updatedCategory.Name.Should().NotBeEquivalentTo(category.Name);
 		updatedCategory.ModifiedAt.Should().BeGreaterThanOrEqualTo(category.ModifiedAt);
 		updatedCategory.CategoryId.Should().Be(otherCategoryId);
 
-		await _client.DeleteCategoryAsync(categoryId);
+		await _client.DeleteCategoryAsync(otherCategoryId);
 
 		(await FluentActions
-				.Awaiting(() => _client.GetCategoryAsync(categoryId))
+				.Awaiting(() => _client.GetCategoryAsync(otherCategoryId))
 				.Should()
 				.ThrowExactlyAsync<HttpRequestException>())
 			.Which.StatusCode.Should()
 			.Be(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task Add_WithLinkedProduct_ShouldCreateExpected()
+	{
+		await _client.PutCategoryAsync(_categoryId, new() { Name = $"{_categoryId:N}", LinkProduct = true });
+
+		var category = await _client.GetCategoryAsync(_categoryId);
+		var linkedProduct = await _client.GetProductAsync(_categoryId);
+		linkedProduct.Name.Should().Be(category.Name);
+
+		var newName = $"{Guid.NewGuid():N}";
+		await _client.PutCategoryAsync(_categoryId, new() { Name = newName, LinkProduct = true });
+		var updatedCategory = await _client.GetCategoryAsync(_categoryId);
+		linkedProduct = await _client.GetProductAsync(_categoryId);
+		updatedCategory.Name.Should().Be(newName);
+		linkedProduct.Name.Should().Be(newName);
+
+		await _client.PutCategoryAsync(_categoryId, new() { Name = newName, LinkProduct = false });
+		updatedCategory = await _client.GetCategoryAsync(_categoryId);
+		updatedCategory.LinkedProductId.Should().BeNull();
+	}
+
+	[TearDown]
+	public async Task TearDownAsync()
+	{
+		var categories = await _client.GetCategoriesAsync();
+		var category = categories.SingleOrDefault(category => category.Id == _categoryId);
+		if (category is not null)
+		{
+			await _client.DeleteCategoryAsync(category.Id);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #720

Changes proposed in this pull request:
* Add ability to add shared database migrations to the data project instead of copying same SQL for all databases
* Create an optional product for each category, and automatically update it's name together with the category
