### PR TITLE
Bump coverlet.collector to 6.0.0-preview.7.gd93613826b

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,10 @@
 		<PackageVersion Include="Avalonia.Diagnostics" Version="0.10.18"/>
 		<PackageVersion Include="Avalonia.Xaml.Behaviors" Version="0.10.18"/>
 		<PackageVersion Include="Bogus" Version="34.0.2"/>
-		<PackageVersion Include="coverlet.collector" Version="3.2.0"/>
+		<PackageVersion Include="coverlet.collector" Version="6.0.0-preview.7.gd93613826b">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageVersion>
 		<PackageVersion Include="CsvHelper" Version="30.0.1"/>
 		<PackageVersion Include="Dapper" Version="2.0.123"/>
 		<PackageVersion Include="dbup-core" Version="5.0.10"/>

--- a/nuget.config
+++ b/nuget.config
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
 	<packageSources>
 		<clear />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+		<add key="coverlet" value="https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json" />
 	</packageSources>
 
 	<packageSourceMapping>
 		<packageSource key="nuget.org">
 			<package pattern="*" />
+		</packageSource>
+		<packageSource key="coverlet">
+			<package pattern="coverlet*" />
 		</packageSource>
 	</packageSourceMapping>
 </configuration>

--- a/tests/Gnomeshade.Avalonia.Core.Tests/packages.lock.json
+++ b/tests/Gnomeshade.Avalonia.Core.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.Data.Tests.Integration/packages.lock.json
+++ b/tests/Gnomeshade.Data.Tests.Integration/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "CsvHelper": {
         "type": "Direct",

--- a/tests/Gnomeshade.Desktop.Tests/packages.lock.json
+++ b/tests/Gnomeshade.Desktop.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.TestingHelpers/packages.lock.json
+++ b/tests/Gnomeshade.TestingHelpers/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.WebApi.Client.Tests/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Client.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.WebApi.Tests.Integration.Oidc/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.Oidc/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.WebApi.Tests.Integration.PostgreSQL/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.PostgreSQL/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.WebApi.Tests.Integration.Sqlite/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests.Integration.Sqlite/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",

--- a/tests/Gnomeshade.WebApi.Tests/packages.lock.json
+++ b/tests/Gnomeshade.WebApi.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[3.2.0, )",
-        "resolved": "3.2.0",
-        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+        "requested": "[6.0.0-preview.7.gd93613826b, )",
+        "resolved": "6.0.0-preview.7.gd93613826b",
+        "contentHash": "V9YncQoY1U8aaedGS64np834ntJCBrsRtw5c76MF822539S+y3+LAhmS3ykecmtGpUi5XcbJRfXheIVaAh2VTQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Changes proposed in this pull request:
* Update coverlet.collector to latest nightly version, which correctly generates coverage for Gnomeshade.Avalonia.Core
