### PR TITLE
Add OpenTelemetryOptions to service collection

### DIFF
--- a/source/Gnomeshade.WebApi/Configuration/ConfigureOtlpExporterOptions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/ConfigureOtlpExporterOptions.cs
@@ -25,6 +25,6 @@ internal sealed class ConfigureOtlpExporterOptions : IConfigureOptions<OtlpExpor
 		var telemetryOptions = _optionsMonitor.CurrentValue;
 
 		options.Endpoint = telemetryOptions.ExporterEndpoint;
-		options.Protocol = OtlpExportProtocol.Grpc;
+		options.Protocol = telemetryOptions.ExportProtocol;
 	}
 }

--- a/source/Gnomeshade.WebApi/Configuration/OpenTelemetryExtensions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/OpenTelemetryExtensions.cs
@@ -27,6 +27,8 @@ internal static class OpenTelemetryExtensions
 		this IServiceCollection services,
 		IConfiguration configuration)
 	{
+		services.AddValidatedOptions<OpenTelemetryOptions>(configuration);
+
 		var telemetryOptions = configuration.GetValid<OpenTelemetryOptions>();
 		if (!telemetryOptions.Enabled)
 		{

--- a/source/Gnomeshade.WebApi/Configuration/Options/OpenTelemetryOptions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/Options/OpenTelemetryOptions.cs
@@ -6,6 +6,8 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
+using OpenTelemetry.Exporter;
+
 namespace Gnomeshade.WebApi.Configuration.Options;
 
 /// <summary>Options for configuring Open Telemetry.</summary>
@@ -27,4 +29,7 @@ public sealed class OpenTelemetryOptions
 	/// <summary>Gets the endpoint to which to send the telemetry. Defaults to localhost.</summary>
 	[Required]
 	public Uri ExporterEndpoint { get; init; } = new("http://localhost:4317");
+
+	/// <summary>Gets the protocol to use for exporting data.</summary>
+	public OtlpExportProtocol ExportProtocol { get; init; }
 }

--- a/source/Gnomeshade.WebApi/Configuration/ServiceCollectionExtensions.cs
+++ b/source/Gnomeshade.WebApi/Configuration/ServiceCollectionExtensions.cs
@@ -4,17 +4,22 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+using JetBrains.Annotations;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using static System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
+
+using static JetBrains.Annotations.ImplicitUseKindFlags;
+using static JetBrains.Annotations.ImplicitUseTargetFlags;
 
 namespace Gnomeshade.WebApi.Configuration;
 
 internal static class ServiceCollectionExtensions
 {
 	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = $"{nameof(DynamicallyAccessedMembersAttribute)} indicates what is dynamically accessed")]
-	internal static IServiceCollection AddValidatedOptions<[DynamicallyAccessedMembers(All)] TOptions>(
+	internal static IServiceCollection AddValidatedOptions<[DynamicallyAccessedMembers(All), MeansImplicitUse(Assign, Members)] TOptions>(
 		this IServiceCollection services,
 		IConfiguration configuration)
 		where TOptions : class


### PR DESCRIPTION
Fixes #748

Currently only the default values were used, ignoring any changes made in `IConfiguration`. This should fix the issue, since locally I had an exporter running on the default endpoint.

This doesn't explain why the troubleshooting steps didn't work in ubuntu, though.
