### PR TITLE
Fix forced reentry of desktop client configuration before each login

### DIFF
--- a/source/Gnomeshade.Avalonia.Core/MainWindowViewModel.cs
+++ b/source/Gnomeshade.Avalonia.Core/MainWindowViewModel.cs
@@ -73,6 +73,7 @@ public sealed class MainWindowViewModel : ViewModelBase
 		if (apiBaseAddress is not null)
 		{
 			await SwitchToLogin();
+			return;
 		}
 
 		var configurationWizardViewModel = _serviceProvider.GetRequiredService<ConfigurationWizardViewModel>();


### PR DESCRIPTION
Changes proposed in this pull request:
* Return after successfully logging in, instead of continuing to open the configuration view
