### PR TITLE
Store identity ids as uuid instead of text

### DIFF
--- a/source/Gnomeshade.Data.PostgreSQL/Gnomeshade.Data.PostgreSQL.csproj
+++ b/source/Gnomeshade.Data.PostgreSQL/Gnomeshade.Data.PostgreSQL.csproj
@@ -84,6 +84,7 @@
 		<EmbeddedResource Include="Migrations\00000024_refunded_by.sql" />
 		<EmbeddedResource Include="Migrations\00000025_bank_reference.sql" />
 		<EmbeddedResource Include="Migrations\00000027_remove_disabled.sql" />
+		<EmbeddedResource Include="Migrations\00000028_identity_id_type.sql" />
 	</ItemGroup>
 
 </Project>

--- a/source/Gnomeshade.Data.PostgreSQL/Migrations/00000028_identity_id_type.sql
+++ b/source/Gnomeshade.Data.PostgreSQL/Migrations/00000028_identity_id_type.sql
@@ -1,0 +1,43 @@
+ALTER TABLE IF EXISTS "AspNetUserClaims"
+	DROP CONSTRAINT "FK_AspNetUserClaims_AspNetUsers_UserId";
+
+ALTER TABLE IF EXISTS "AspNetUserLogins"
+	DROP CONSTRAINT "FK_AspNetUserLogins_AspNetUsers_UserId";
+
+ALTER TABLE IF EXISTS "AspNetUserRoles"
+	DROP CONSTRAINT "FK_AspNetUserRoles_AspNetUsers_UserId",
+    DROP CONSTRAINT "FK_AspNetUserRoles_AspNetRoles_RoleId";
+
+ALTER TABLE IF EXISTS "AspNetUserTokens"
+	DROP CONSTRAINT "FK_AspNetUserTokens_AspNetUsers_UserId";
+
+ALTER TABLE IF EXISTS "AspNetRoleClaims"
+	DROP CONSTRAINT "FK_AspNetRoleClaims_AspNetRoles_RoleId";
+
+ALTER TABLE IF EXISTS "AspNetUsers"
+	ALTER COLUMN "Id" TYPE uuid USING "Id"::uuid;
+
+ALTER TABLE IF EXISTS "AspNetRoles"
+	ALTER COLUMN "Id" TYPE uuid USING "Id"::uuid;
+
+ALTER TABLE IF EXISTS "AspNetUserClaims"
+	ALTER COLUMN "UserId" TYPE uuid USING "UserId"::uuid,
+	ADD CONSTRAINT "FK_AspNetUserClaims_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id");
+
+ALTER TABLE IF EXISTS "AspNetUserLogins"
+	ALTER COLUMN "UserId" TYPE uuid USING "UserId"::uuid,
+	ADD CONSTRAINT "FK_AspNetUserLogins_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id");
+
+ALTER TABLE IF EXISTS "AspNetUserRoles"
+	ALTER COLUMN "UserId" TYPE uuid USING "UserId"::uuid,
+	ALTER COLUMN "RoleId" TYPE uuid USING "RoleId"::uuid,
+	ADD CONSTRAINT "FK_AspNetUserRoles_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id"),
+	ADD CONSTRAINT "FK_AspNetUserRoles_AspNetRoles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "AspNetRoles" ("Id");
+
+ALTER TABLE IF EXISTS "AspNetUserTokens"
+	ALTER COLUMN "UserId" TYPE uuid USING "UserId"::uuid,
+	ADD CONSTRAINT "FK_AspNetUserTokens_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id");
+
+ALTER TABLE IF EXISTS "AspNetRoleClaims"
+	ALTER COLUMN "RoleId" TYPE uuid USING "RoleId"::uuid,
+	ADD CONSTRAINT "FK_AspNetRoleClaims_AspNetRoles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "AspNetRoles" ("Id");

--- a/source/Gnomeshade.Data.PostgreSQL/Migrations/PostgreSQLIdentityContextModelSnapshot.cs
+++ b/source/Gnomeshade.Data.PostgreSQL/Migrations/PostgreSQLIdentityContextModelSnapshot.cs
@@ -22,10 +22,38 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("Gnomeshade.Data.Identity.ApplicationRole", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasDatabaseName("RoleNameIndex");
+
+                    b.ToTable("AspNetRoles", (string)null);
+                });
+
             modelBuilder.Entity("Gnomeshade.Data.Identity.ApplicationUser", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("text");
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
 
                     b.Property<int>("AccessFailedCount")
                         .HasColumnType("integer");
@@ -90,33 +118,7 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("text");
-
-                    b.Property<string>("ConcurrencyStamp")
-                        .IsConcurrencyToken()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<string>("NormalizedName")
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("NormalizedName")
-                        .IsUnique()
-                        .HasDatabaseName("RoleNameIndex");
-
-                    b.ToTable("AspNetRoles", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -130,9 +132,8 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("text");
 
-                    b.Property<string>("RoleId")
-                        .IsRequired()
-                        .HasColumnType("text");
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -141,7 +142,7 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetRoleClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -155,9 +156,8 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("text");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("text");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
 
                     b.HasKey("Id");
 
@@ -166,7 +166,7 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetUserClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
                     b.Property<string>("LoginProvider")
                         .HasColumnType("text");
@@ -177,9 +177,8 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("text");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("text");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
 
                     b.HasKey("LoginProvider", "ProviderKey");
 
@@ -188,13 +187,13 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetUserLogins", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.Property<string>("UserId")
-                        .HasColumnType("text");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
 
-                    b.Property<string>("RoleId")
-                        .HasColumnType("text");
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uuid");
 
                     b.HasKey("UserId", "RoleId");
 
@@ -203,10 +202,10 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetUserRoles", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.Property<string>("UserId")
-                        .HasColumnType("text");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
 
                     b.Property<string>("LoginProvider")
                         .HasColumnType("text");
@@ -222,16 +221,16 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                     b.ToTable("AspNetUserTokens", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Gnomeshade.Data.Identity.ApplicationRole", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()
@@ -240,7 +239,7 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()
@@ -249,9 +248,9 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Gnomeshade.Data.Identity.ApplicationRole", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -264,7 +263,7 @@ namespace Gnomeshade.Data.PostgreSQL.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()

--- a/source/Gnomeshade.Data.PostgreSQL/ServiceCollectionExtensions.cs
+++ b/source/Gnomeshade.Data.PostgreSQL/ServiceCollectionExtensions.cs
@@ -9,7 +9,6 @@ using Gnomeshade.Data.Migrations;
 using Gnomeshade.Data.PostgreSQL.Dapper;
 using Gnomeshade.Data.PostgreSQL.Migrations;
 
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -43,10 +42,4 @@ public static class ServiceCollectionExtensions
 				ServiceLifetime.Scoped)
 			.AddDbContext<IdentityContext, PostgreSQLIdentityContext>();
 	}
-
-	/// <summary>Adds an Entity Framework implementation of identity information stores for PostgreSQL.</summary>
-	/// <param name="identityBuilder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
-	/// <returns><paramref name="identityBuilder"/> with identity stored added.</returns>
-	public static IdentityBuilder AddPostgreSQLIdentity(this IdentityBuilder identityBuilder) => identityBuilder
-		.AddEntityFrameworkStores<PostgreSQLIdentityContext>();
 }

--- a/source/Gnomeshade.Data.Sqlite/Migrations/SqliteIdentityContextModelSnapshot.cs
+++ b/source/Gnomeshade.Data.Sqlite/Migrations/SqliteIdentityContextModelSnapshot.cs
@@ -17,9 +17,37 @@ namespace Gnomeshade.Data.Sqlite.Migrations
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.5");
 
+            modelBuilder.Entity("Gnomeshade.Data.Identity.ApplicationRole", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(256)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(256)
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasDatabaseName("RoleNameIndex");
+
+                    b.ToTable("AspNetRoles", (string)null);
+                });
+
             modelBuilder.Entity("Gnomeshade.Data.Identity.ApplicationUser", b =>
                 {
-                    b.Property<string>("Id")
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT");
 
                     b.Property<int>("AccessFailedCount")
@@ -85,33 +113,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("ConcurrencyStamp")
-                        .IsConcurrencyToken()
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(256)
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("NormalizedName")
-                        .HasMaxLength(256)
-                        .HasColumnType("TEXT");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("NormalizedName")
-                        .IsUnique()
-                        .HasDatabaseName("RoleNameIndex");
-
-                    b.ToTable("AspNetRoles", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -123,8 +125,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("RoleId")
-                        .IsRequired()
+                    b.Property<Guid>("RoleId")
                         .HasColumnType("TEXT");
 
                     b.HasKey("Id");
@@ -134,7 +135,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetRoleClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -146,8 +147,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
+                    b.Property<Guid>("UserId")
                         .HasColumnType("TEXT");
 
                     b.HasKey("Id");
@@ -157,7 +157,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetUserClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
                     b.Property<string>("LoginProvider")
                         .HasColumnType("TEXT");
@@ -168,8 +168,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.Property<string>("ProviderDisplayName")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
+                    b.Property<Guid>("UserId")
                         .HasColumnType("TEXT");
 
                     b.HasKey("LoginProvider", "ProviderKey");
@@ -179,12 +178,12 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetUserLogins", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.Property<string>("UserId")
+                    b.Property<Guid>("UserId")
                         .HasColumnType("TEXT");
 
-                    b.Property<string>("RoleId")
+                    b.Property<Guid>("RoleId")
                         .HasColumnType("TEXT");
 
                     b.HasKey("UserId", "RoleId");
@@ -194,9 +193,9 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetUserRoles", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.Property<string>("UserId")
+                    b.Property<Guid>("UserId")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("LoginProvider")
@@ -213,16 +212,16 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                     b.ToTable("AspNetUserTokens", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Gnomeshade.Data.Identity.ApplicationRole", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()
@@ -231,7 +230,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()
@@ -240,9 +239,9 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Gnomeshade.Data.Identity.ApplicationRole", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -255,7 +254,7 @@ namespace Gnomeshade.Data.Sqlite.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
                     b.HasOne("Gnomeshade.Data.Identity.ApplicationUser", null)
                         .WithMany()

--- a/source/Gnomeshade.Data.Sqlite/ServiceCollectionExtensions.cs
+++ b/source/Gnomeshade.Data.Sqlite/ServiceCollectionExtensions.cs
@@ -12,7 +12,6 @@ using Gnomeshade.Data.Migrations;
 using Gnomeshade.Data.Sqlite.Dapper;
 using Gnomeshade.Data.Sqlite.Migrations;
 
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -52,10 +51,4 @@ public static class ServiceCollectionExtensions
 			.AddSingleton<DbConnection>(provider => provider.GetRequiredService<SqliteConnection>())
 			.AddDbContext<IdentityContext, SqliteIdentityContext>();
 	}
-
-	/// <summary>Adds an Entity Framework implementation of identity information stores for Sqlite.</summary>
-	/// <param name="identityBuilder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
-	/// <returns><paramref name="identityBuilder"/> with identity stored added.</returns>
-	public static IdentityBuilder AddSqliteIdentity(this IdentityBuilder identityBuilder) => identityBuilder
-		.AddEntityFrameworkStores<SqliteIdentityContext>();
 }

--- a/source/Gnomeshade.Data/Identity/ApplicationRole.cs
+++ b/source/Gnomeshade.Data/Identity/ApplicationRole.cs
@@ -1,0 +1,27 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+
+using Microsoft.AspNetCore.Identity;
+
+namespace Gnomeshade.Data.Identity;
+
+/// <summary>Application identity role.</summary>
+public sealed class ApplicationRole : IdentityRole<Guid>
+{
+	/// <summary>Initializes a new instance of the <see cref="ApplicationRole"/> class.</summary>
+	public ApplicationRole()
+	{
+		Id = Guid.NewGuid();
+	}
+
+	/// <summary>Initializes a new instance of the <see cref="ApplicationRole"/> class.</summary>
+	/// <param name="roleName">The role name.</param>
+	public ApplicationRole(string roleName)
+		: this()
+	{
+		Name = roleName;
+	}
+}

--- a/source/Gnomeshade.Data/Identity/ApplicationRoleStore.cs
+++ b/source/Gnomeshade.Data/Identity/ApplicationRoleStore.cs
@@ -1,0 +1,28 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+
+namespace Gnomeshade.Data.Identity;
+
+/// <summary>Persistence store for <see cref="ApplicationRole"/>.</summary>
+public sealed class ApplicationRoleStore : RoleStore<ApplicationRole, IdentityContext, Guid>
+{
+	/// <summary>Initializes a new instance of the <see cref="ApplicationRoleStore"/> class.</summary>
+	/// <param name="context">The <see cref="IdentityContext"/>.</param>
+	/// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
+	public ApplicationRoleStore(IdentityContext context, IdentityErrorDescriber? describer = null)
+		: base(context, describer)
+	{
+	}
+
+	/// <inheritdoc />
+	public override Guid ConvertIdFromString(string? id) => id.ConvertIdFromString();
+
+	/// <inheritdoc />
+	public override string ConvertIdToString(Guid id) => id.ConvertIdToString();
+}

--- a/source/Gnomeshade.Data/Identity/ApplicationUser.cs
+++ b/source/Gnomeshade.Data/Identity/ApplicationUser.cs
@@ -2,13 +2,30 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System;
+
 using Microsoft.AspNetCore.Identity;
 
 namespace Gnomeshade.Data.Identity;
 
 /// <summary>Application identity user.</summary>
-public sealed class ApplicationUser : IdentityUser
+public sealed class ApplicationUser : IdentityUser<Guid>
 {
+	/// <summary>Initializes a new instance of the <see cref="ApplicationUser"/> class.</summary>
+	public ApplicationUser()
+	{
+		Id = Guid.NewGuid();
+		SecurityStamp = Guid.NewGuid().ToString();
+	}
+
+	/// <summary>Initializes a new instance of the <see cref="ApplicationUser"/> class.</summary>
+	/// <param name="userName">The user name.</param>
+	public ApplicationUser(string userName)
+		: this()
+	{
+		UserName = userName;
+	}
+
 	/// <summary>Gets or sets the full name for this user.</summary>
 	public string FullName { get; set; } = null!;
 }

--- a/source/Gnomeshade.Data/Identity/ApplicationUserStore.cs
+++ b/source/Gnomeshade.Data/Identity/ApplicationUserStore.cs
@@ -1,0 +1,28 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+
+namespace Gnomeshade.Data.Identity;
+
+/// <summary>Persistence store for <see cref="ApplicationUser"/> and <see cref="ApplicationRole"/>.</summary>
+public sealed class ApplicationUserStore : UserStore<ApplicationUser, ApplicationRole, IdentityContext, Guid>
+{
+	/// <summary>Initializes a new instance of the <see cref="ApplicationUserStore"/> class.</summary>
+	/// <param name="context">The <see cref="IdentityContext"/>.</param>
+	/// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
+	public ApplicationUserStore(IdentityContext context, IdentityErrorDescriber? describer = null)
+		: base(context, describer)
+	{
+	}
+
+	/// <inheritdoc />
+	public override Guid ConvertIdFromString(string? id) => id.ConvertIdFromString();
+
+	/// <inheritdoc />
+	public override string ConvertIdToString(Guid id) => id.ConvertIdToString();
+}

--- a/source/Gnomeshade.Data/Identity/IdentityContext.cs
+++ b/source/Gnomeshade.Data/Identity/IdentityContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System;
+
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -9,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Gnomeshade.Data.Identity;
 
 /// <summary>Identity database context for <see cref="ApplicationUser"/>.</summary>
-public abstract class IdentityContext : IdentityDbContext<ApplicationUser>
+public abstract class IdentityContext : IdentityDbContext<ApplicationUser, ApplicationRole, Guid>
 {
 	/// <summary>The name of the Entity Framework migrations history table.</summary>
 	protected const string MigrationHistoryTableName = "__EFMigrationsHistory";

--- a/source/Gnomeshade.Data/Identity/IdentityIdExtensions.cs
+++ b/source/Gnomeshade.Data/Identity/IdentityIdExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright 2021 Valters Melnalksnis
+// Licensed under the GNU Affero General Public License v3.0 or later.
+// See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Gnomeshade.Data.Identity;
+
+/// <summary>Methods for converting <see cref="Guid"/> to and from <see cref="string"/> for identity managers.</summary>
+public static class IdentityIdExtensions
+{
+	private const string _guidFormat = "D";
+
+	/// <summary>Converts the string representation of a GUID to the equivalent <see cref="Guid"/> structure.</summary>
+	/// <param name="id">The string id to convert.</param>
+	/// <returns>An instance of <see cref="Guid"/> representing the provided <paramref name="id"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+	public static Guid ConvertIdFromString(this string? id)
+	{
+		ArgumentNullException.ThrowIfNull(id, nameof(id));
+		return Guid.ParseExact(id, _guidFormat);
+	}
+
+	/// <summary>Converts the provided <paramref name="id"/> to its string representation.</summary>
+	/// <param name="id">The id to convert to string.</param>
+	/// <returns>The string representation of <paramref name="id"/>.</returns>
+	public static string ConvertIdToString(this Guid id) => id.ToString(_guidFormat, CultureInfo.InvariantCulture);
+}

--- a/source/Gnomeshade.Data/ServiceCollectionExtensions.cs
+++ b/source/Gnomeshade.Data/ServiceCollectionExtensions.cs
@@ -2,9 +2,12 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using Gnomeshade.Data.Identity;
 using Gnomeshade.Data.Repositories;
 
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Gnomeshade.Data;
 
@@ -36,5 +39,17 @@ public static class ServiceCollectionExtensions
 			.AddScoped<CategoryRepository>()
 			.AddScoped<TransactionUnitOfWork>()
 			.AddScoped<UserUnitOfWork>();
+	}
+
+	/// <summary>Adds an Entity Framework implementation of identity information stores.</summary>
+	/// <param name="identityBuilder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
+	/// <returns><paramref name="identityBuilder"/> with identity stored added.</returns>
+	public static IdentityBuilder AddIdentityStores(this IdentityBuilder identityBuilder)
+	{
+		var services = identityBuilder.Services;
+		services.TryAddScoped<IUserStore<ApplicationUser>, ApplicationUserStore>();
+		services.TryAddScoped<IRoleStore<ApplicationRole>, ApplicationRoleStore>();
+
+		return identityBuilder;
 	}
 }

--- a/source/Gnomeshade.Data/UserUnitOfWork.cs
+++ b/source/Gnomeshade.Data/UserUnitOfWork.cs
@@ -2,7 +2,6 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
-using System;
 using System.Data.Common;
 using System.Threading.Tasks;
 
@@ -46,7 +45,7 @@ public sealed class UserUnitOfWork
 	/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 	public async Task CreateUserAsync(ApplicationUser applicationUser)
 	{
-		var userId = Guid.ParseExact(applicationUser.Id, "D");
+		var userId = applicationUser.Id;
 		var fullName = applicationUser.FullName;
 		var user = new UserEntity { Id = userId, ModifiedByUserId = userId };
 

--- a/source/Gnomeshade.WebApi/Areas/Admin/Pages/Users/Index.cshtml.cs
+++ b/source/Gnomeshade.WebApi/Areas/Admin/Pages/Users/Index.cshtml.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,7 +55,7 @@ public sealed class Index : PageModel
 		foreach (var userEntity in userEntities)
 		{
 			var counterparty = counterparties.Single(entity => entity.Id == userEntity.CounterpartyId);
-			var identityUser = identityUsers.SingleOrDefault(user => user.Id == userEntity.Id.ToString());
+			var identityUser = identityUsers.SingleOrDefault(user => user.Id == userEntity.Id);
 
 			var lockoutEnabled = identityUser is null
 				? (bool?)null
@@ -77,7 +76,7 @@ public sealed class Index : PageModel
 
 	private async Task<PageResult> SetLockoutEndDateAsync(Guid id, DateTimeOffset? lockoutEnd)
 	{
-		var identityUser = await _userManager.FindByIdAsync(id.ToString("D", CultureInfo.InvariantCulture));
+		var identityUser = await _userManager.FindByIdAsync(id.ConvertIdToString());
 		if (identityUser is null)
 		{
 			throw new InvalidOperationException();

--- a/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -160,11 +160,10 @@ public sealed class ExternalLogin : PageModel
 
 		if (ModelState.IsValid)
 		{
-			var user = new ApplicationUser
+			var user = new ApplicationUser(Input.UserName ?? Input.Email)
 			{
 				Email = Input.Email,
 				FullName = Input.FullName,
-				UserName = Input.UserName ?? Input.Email,
 			};
 
 			var result = await _userManager.CreateAsync(user);

--- a/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/source/Gnomeshade.WebApi/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -83,11 +83,10 @@ public sealed class Register : PageModel
 		ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
 		if (ModelState.IsValid)
 		{
-			var user = new ApplicationUser
+			var user = new ApplicationUser(Input.UserName)
 			{
 				Email = Input.Email,
 				FullName = Input.FullName,
-				UserName = Input.UserName,
 			};
 
 			var result = await _userManager.CreateAsync(user, Input.Password);
@@ -96,7 +95,7 @@ public sealed class Register : PageModel
 			{
 				LogMessages.UserCreated(_logger);
 
-				var identityUser = await _userManager.FindByNameAsync(user.UserName);
+				var identityUser = await _userManager.FindByNameAsync(Input.UserName);
 				if (identityUser is null)
 				{
 					throw new InvalidOperationException("Could not find user by name after creating it");

--- a/source/Gnomeshade.WebApi/Startup.cs
+++ b/source/Gnomeshade.WebApi/Startup.cs
@@ -77,23 +77,17 @@ public class Startup
 			.AddValidatedOptions<AdminOptions>(_configuration)
 			.AddTransient<IStartupFilter, AdminUserStartupFilter>();
 
-		var databaseProvider = _configuration.GetValid<DatabaseOptions>().Provider;
-		var identityBuilder = databaseProvider switch
+		var databaseProvider = DatabaseProvider.FromName(_configuration.GetValid<DatabaseOptions>().Provider, true);
+		_ = databaseProvider switch
 		{
-			_ when databaseProvider.Equals(DatabaseProvider.PostgreSQL.Name, StringComparison.OrdinalIgnoreCase) => services
-				.AddPostgreSQL(_configuration)
-				.AddIdentity<ApplicationUser, IdentityRole>()
-				.AddPostgreSQLIdentity(),
-
-			_ when databaseProvider.Equals(DatabaseProvider.Sqlite.Name, StringComparison.OrdinalIgnoreCase) => services
-				.AddSqlite(_configuration)
-				.AddIdentity<ApplicationUser, IdentityRole>()
-				.AddSqliteIdentity(),
-
+			_ when databaseProvider == DatabaseProvider.PostgreSQL => services.AddPostgreSQL(_configuration),
+			_ when databaseProvider == DatabaseProvider.Sqlite => services.AddSqlite(_configuration),
 			_ => throw new ArgumentOutOfRangeException(nameof(databaseProvider), databaseProvider, "Unsupported database provider"),
 		};
 
-		identityBuilder
+		services
+			.AddIdentity<ApplicationUser, ApplicationRole>()
+			.AddIdentityStores()
 			.AddDefaultUI()
 			.AddDefaultTokenProviders();
 

--- a/source/Gnomeshade.WebApi/V1/Authorization/ApplicationUserHandler.cs
+++ b/source/Gnomeshade.WebApi/V1/Authorization/ApplicationUserHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
-using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -57,8 +56,7 @@ public sealed class ApplicationUserHandler : AuthorizationHandler<ApplicationUse
 			return;
 		}
 
-		var id = new Guid(identityUser.Id);
-		var applicationUser = await _userRepository.FindByIdAsync(id);
+		var applicationUser = await _userRepository.FindByIdAsync(identityUser.Id);
 		if (applicationUser is null)
 		{
 			context.Fail(new(this, "Failed to find application user"));

--- a/source/Gnomeshade.WebApi/V1/Controllers/AuthenticationController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/AuthenticationController.cs
@@ -83,7 +83,7 @@ public sealed class AuthenticationController : ControllerBase
 
 		var claims = new List<Claim>
 		{
-			new(ClaimTypes.NameIdentifier, user.Id),
+			new(ClaimTypes.NameIdentifier, user.Id.ConvertIdToString()),
 			new(ClaimTypes.Name, user.FullName),
 			new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
 		};
@@ -113,7 +113,6 @@ public sealed class AuthenticationController : ControllerBase
 	public async Task<ActionResult> Register([FromBody] RegistrationModel registration)
 	{
 		var user = _mapper.Map<ApplicationUser>(registration);
-		user.SecurityStamp = Guid.NewGuid().ToString();
 
 		var creationResult = await _userManager.CreateAsync(user, registration.Password);
 		if (!creationResult.Succeeded)


### PR DESCRIPTION
This should help with #115.

Changes proposed in this pull request:
* Change identity table primary keys from text to uuid
* Simplify database access setup

Sqlite did not require any migrations, since everything is stored as text anyway. EF could not generate a working migration for Postgresql due to foreign keys, so wrote it in SQL since the plan is to move away from EF anyway.