### PR TITLE
fix(api): Check for references before marking entity as deleted

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -67,9 +67,14 @@
 			<ul></ul>
 		</section>
 
-		<section id="unreleased_fixed" hidden="hidden">
+		<section id="unreleased_fixed">
 			<h3>Fixed</h3>
-			<ul></ul>
+			<ul>
+				<li>
+					Check for references before marking entity as deleted in
+					<a href="https://github.com/VMelnalksnis/Gnomeshade/pull/859">#859</a>
+				</li>
+			</ul>
 		</section>
 
 		<section id="unreleased_security">

--- a/source/Gnomeshade.Data/Repositories/Queries/Product/Delete.sql
+++ b/source/Gnomeshade.Data/Repositories/Queries/Product/Delete.sql
@@ -32,10 +32,18 @@
 				  AND purchases.deleted_at IS NULL
 				  AND transactions.deleted_at IS NULL))
 			AND products.deleted_at IS NULL
+			AND products.id = @id),
+
+	 referencing_purchases AS
+		 (SELECT purchases.id
+		  FROM purchases
+				   INNER JOIN products on products.id = purchases.product_id
+		  WHERE purchases.deleted_at IS NULL
 			AND products.id = @id)
 
 UPDATE products
 SET deleted_at         = CURRENT_TIMESTAMP,
 	deleted_by_user_id = @userId
 FROM accessable
-WHERE products.id IN (SELECT id FROM accessable);
+WHERE products.id IN (SELECT id FROM accessable)
+  AND (SELECT count(id) FROM referencing_purchases) = 0;

--- a/source/Gnomeshade.Data/Repositories/Repository.cs
+++ b/source/Gnomeshade.Data/Repositories/Repository.cs
@@ -87,11 +87,12 @@ public abstract class Repository<TEntity>
 	/// <param name="id">The id of the entity to delete.</param>
 	/// <param name="userId">The id of the user requesting access to the entity.</param>
 	/// <returns>The number of affected rows.</returns>
-	public async Task DeleteAsync(Guid id, Guid userId)
+	public async Task<int> DeleteAsync(Guid id, Guid userId)
 	{
 		Logger.DeletingEntity(id);
 		var count = await DbConnection.ExecuteAsync(DeleteSql, new { id, userId });
 		Logger.DeletedRows(count);
+		return count;
 	}
 
 	/// <summary>Deletes the entity with the specified id using the specified database transaction.</summary>
@@ -99,11 +100,12 @@ public abstract class Repository<TEntity>
 	/// <param name="userId">The id of the user requesting access to the entity.</param>
 	/// <param name="dbTransaction">The database transaction to use for the query.</param>
 	/// <returns>The number of affected rows.</returns>
-	public async Task DeleteAsync(Guid id, Guid userId, DbTransaction dbTransaction)
+	public async Task<int> DeleteAsync(Guid id, Guid userId, DbTransaction dbTransaction)
 	{
 		Logger.DeletingEntityWithTransaction(id);
 		var count = await DbConnection.ExecuteAsync(DeleteSql, new { id, userId }, dbTransaction);
 		Logger.DeletedRows(count);
+		return count;
 	}
 
 	/// <summary>Gets all entities.</summary>

--- a/source/Gnomeshade.WebApi/V1/Controllers/CategoriesController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/CategoriesController.cs
@@ -71,7 +71,7 @@ public sealed class CategoriesController : CreatableBase<CategoryRepository, Cat
 	/// <inheritdoc cref="IProductClient.DeleteCategoryAsync"/>
 	/// <response code="204">The category was deleted successfully.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 
 	/// <inheritdoc />

--- a/source/Gnomeshade.WebApi/V1/Controllers/LinksController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/LinksController.cs
@@ -55,7 +55,7 @@ public sealed class LinksController : CreatableBase<LinkRepository, LinkEntity, 
 	/// <response code="204">Link was successfully deleted.</response>
 	/// <response code="404">Link with the specified id does not exist.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 
 	/// <inheritdoc />

--- a/source/Gnomeshade.WebApi/V1/Controllers/LoansController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/LoansController.cs
@@ -62,6 +62,6 @@ public sealed class LoansController : TransactionItemController<LoanRepository, 
 	/// <response code="204">Loan was successfully deleted.</response>
 	/// <response code="404">Loan with the specified id does not exist.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 }

--- a/source/Gnomeshade.WebApi/V1/Controllers/OwnersController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/OwnersController.cs
@@ -52,7 +52,7 @@ public sealed class OwnersController : CreatableBase<OwnerRepository, OwnerEntit
 	/// <inheritdoc cref="IOwnerClient.DeleteOwnerAsync"/>
 	/// <response code="204">The owner was deleted successfully.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 
 	/// <inheritdoc />

--- a/source/Gnomeshade.WebApi/V1/Controllers/OwnershipsController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/OwnershipsController.cs
@@ -51,7 +51,7 @@ public sealed class OwnershipsController : CreatableBase<OwnershipRepository, Ow
 	/// <inheritdoc cref="IOwnerClient.DeleteOwnershipAsync"/>
 	/// <response code="204">The ownership was deleted successfully.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 
 	/// <inheritdoc />

--- a/source/Gnomeshade.WebApi/V1/Controllers/PurchasesController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/PurchasesController.cs
@@ -62,6 +62,6 @@ public sealed class PurchasesController : TransactionItemController<PurchaseRepo
 	/// <response code="204">Purchase was successfully deleted.</response>
 	/// <response code="404">Purchase with the specified id does not exist.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 }

--- a/source/Gnomeshade.WebApi/V1/Controllers/TransactionsController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/TransactionsController.cs
@@ -139,7 +139,7 @@ public sealed class TransactionsController : CreatableBase<TransactionRepository
 	/// <response code="204">Transaction was successfully deleted.</response>
 	/// <response code="404">Transaction with the specified id does not exist.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 
 	/// <inheritdoc cref="ITransactionClient.GetTransactionLinksAsync"/>

--- a/source/Gnomeshade.WebApi/V1/Controllers/TransfersController.cs
+++ b/source/Gnomeshade.WebApi/V1/Controllers/TransfersController.cs
@@ -62,6 +62,6 @@ public sealed class TransfersController : TransactionItemController<TransferRepo
 	/// <response code="204">Transfer was successfully deleted.</response>
 	/// <response code="404">Transfer with the specified id does not exist.</response>
 	// ReSharper disable once RedundantOverriddenMember
-	public override Task<StatusCodeResult> Delete(Guid id) =>
+	public override Task<ActionResult> Delete(Guid id) =>
 		base.Delete(id);
 }

--- a/tests/Gnomeshade.TestingHelpers/Models/GnomeshadeClientExtensions.cs
+++ b/tests/Gnomeshade.TestingHelpers/Models/GnomeshadeClientExtensions.cs
@@ -73,7 +73,7 @@ public static class GnomeshadeClientExtensions
 		return await accountClient.GetCounterpartyAsync(counterpartyId);
 	}
 
-	public static async Task<Category> CreateCategoryAsync(this IGnomeshadeClient productClient, Guid? ownerId = null)
+	public static async Task<Category> CreateCategoryAsync(this IProductClient productClient, Guid? ownerId = null)
 	{
 		var categoryId = Guid.NewGuid();
 		var category = new CategoryCreation { Name = $"{categoryId:N}", OwnerId = ownerId };

--- a/tests/Gnomeshade.WebApi.Tests.Integration/Fixtures/WebserverTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/Fixtures/WebserverTests.cs
@@ -2,6 +2,11 @@
 // Licensed under the GNU Affero General Public License v3.0 or later.
 // See LICENSE.txt file in the project root for full license information.
 
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
 namespace Gnomeshade.WebApi.Tests.Integration.Fixtures;
 
 [TestFixtureSource(typeof(DatabaseFixtureSource))]
@@ -13,4 +18,19 @@ public abstract class WebserverTests
 	}
 
 	protected WebserverFixture Fixture { get; }
+
+	protected static Task ShouldThrowNotFound(Func<Task> func) =>
+		ShouldThrowHttpRequestException(func, HttpStatusCode.NotFound);
+
+	protected static Task ShouldThrowConflict(Func<Task> func) =>
+		ShouldThrowHttpRequestException(func, HttpStatusCode.Conflict);
+
+	private static async Task ShouldThrowHttpRequestException(Func<Task> func, HttpStatusCode expected)
+	{
+		(await FluentActions
+				.Awaiting(func)
+				.Should()
+				.ThrowExactlyAsync<HttpRequestException>())
+			.Which.StatusCode.Should().Be(expected);
+	}
 }

--- a/tests/Gnomeshade.WebApi.Tests.Integration/V1/Controllers/UnitsControllerTests.cs
+++ b/tests/Gnomeshade.WebApi.Tests.Integration/V1/Controllers/UnitsControllerTests.cs
@@ -3,8 +3,6 @@
 // See LICENSE.txt file in the project root for full license information.
 
 using System;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 using Gnomeshade.WebApi.Client;
@@ -40,13 +38,7 @@ public sealed class UnitsControllerTests : WebserverTests
 		var creationModel = CreateUniqueUnit() with { ParentUnitId = _parentUnit.Id, Multiplier = 10 };
 		await _client.PutUnitAsync(Guid.NewGuid(), creationModel);
 
-		var exception =
-			await FluentActions
-				.Awaiting(() => _client.PutUnitAsync(Guid.NewGuid(), creationModel))
-				.Should()
-				.ThrowExactlyAsync<HttpRequestException>();
-
-		exception.Which.StatusCode.Should().Be(HttpStatusCode.Conflict);
+		await ShouldThrowConflict(() => _client.PutUnitAsync(Guid.NewGuid(), creationModel));
 	}
 
 	[Test]


### PR DESCRIPTION
Fixes #585

Changes proposed in this pull request:
* Check for references before deleting accounts in currency, categories and products

Others currently cannot be removed from the UI, but should also be fixed with time.
