### PR TITLE
Re-enable reflection based JSON serialization

### DIFF
--- a/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
+++ b/source/Gnomeshade.WebApi/Gnomeshade.WebApi.csproj
@@ -10,6 +10,7 @@
 		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<EnableConfigurationBindingGenerator>false</EnableConfigurationBindingGenerator>
+		<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
 
 		<NoWarn>$(NoWarn); CS8002</NoWarn>
 		<SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Reflection based serialization is disabled when running the API outside of tests, see https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2550