### PR TITLE
Bump WixToolset.Sdk from 4.0.3 to 4.0.4

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -99,6 +99,10 @@
 					Bump .NET SDK version in
 					<a href="https://github.com/VMelnalksnis/Gnomeshade/pull/703">#703</a>
 				</li>
+				<li>
+					Bump vulnerable WiX version (<a href="https://www.firegiant.com/blog/2024/2/6/wix-security-releases-available/">Release notes</a>) in
+					<a href="https://github.com/VMelnalksnis/Gnomeshade/pull/1077">#1077</a>
+				</li>
 			</ul>
 		</section>
 	</section>

--- a/source/Gnomeshade.Desktop.Installer/Gnomeshade.Desktop.Installer.wixproj
+++ b/source/Gnomeshade.Desktop.Installer/Gnomeshade.Desktop.Installer.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.3">
+<Project Sdk="WixToolset.Sdk/4.0.4">
 	<PropertyGroup>
 		<SuppressIces>ICE38</SuppressIces>
 		<SuppressSpecificWarnings>0204</SuppressSpecificWarnings>


### PR DESCRIPTION
https://www.firegiant.com/blog/2024/2/6/wix-security-releases-available/