### PR TITLE
Reduce app start time by enabling ReadyToRun

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -63,6 +63,10 @@
 					Removed unused files from published application in wwwroot in
 					<a href="https://github.com/VMelnalksnis/Gnomeshade/pull/1097">#1097</a>
 				</li>
+				<li>
+					Improved desktop app startup time at the cost of file size in
+					<a href="https://github.com/VMelnalksnis/Gnomeshade/pull/1098">#1098</a>
+				</li>
 			</ul>
 		</section>
 

--- a/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
+++ b/source/Gnomeshade.Desktop/Gnomeshade.Desktop.csproj
@@ -7,6 +7,7 @@
 		<ApplicationIcon>Assets/avalonia-logo.ico</ApplicationIcon>
 
 		<PublishTrimmed>true</PublishTrimmed>
+		<PublishReadyToRun>true</PublishReadyToRun>
 		<TrimMode>partial</TrimMode>
 		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>


### PR DESCRIPTION
Changes proposed in this pull request:
* Significantly improve the startup time, but will also more than double the published app size
